### PR TITLE
Add ai_models tests

### DIFF
--- a/open_ticket_ai/tests/src/run/test_ai_models.py
+++ b/open_ticket_ai/tests/src/run/test_ai_models.py
@@ -1,0 +1,42 @@
+import logging
+import pytest
+
+from open_ticket_ai.src.ce.core.config.config_models import AIInferenceServiceConfig
+from open_ticket_ai.src.ce.run.ai_models.ai_inference_service import AIInferenceService
+from open_ticket_ai.src.ce.run.ai_models.hf_local_ai_inference_service import HFAIInferenceService
+
+
+class DummyService(AIInferenceService):
+    """Simple subclass used for testing."""
+
+    def generate_response(self, prompt: str) -> str:
+        return f"dummy:{prompt}"
+
+
+@pytest.fixture
+def example_config():
+    return AIInferenceServiceConfig(id="dummy", provider_key="dummy_provider")
+
+
+def test_ai_inference_service_is_abstract(example_config):
+    with pytest.raises(TypeError):
+        AIInferenceService(example_config)  # type: ignore[abstract]
+
+
+def test_subclass_initialization_assigns_config(example_config):
+    svc = DummyService(example_config)
+    assert svc.ai_inference_config is example_config
+    assert isinstance(svc._logger, logging.Logger)
+    assert svc.generate_response("hi") == "dummy:hi"
+
+
+def test_hf_service_description():
+    assert (
+        HFAIInferenceService.get_description()
+        == "Hugging Face AI Model - Placeholder for future implementation"
+    )
+
+
+def test_hf_service_generate_response_returns_none(example_config):
+    svc = HFAIInferenceService(example_config)
+    assert svc.generate_response("hello") is None


### PR DESCRIPTION
## Summary
- add missing unit tests for AIInferenceService and HuggingFace implementation

## Testing
- `PIP_IGNORE_REQUIRES_PYTHON=1 pip install -e .`
- `python -m spacy download de_core_news_sm`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a7245ae4083279dcc4f3ae7b9d545