### PR TITLE
Add fetcher tests and IBAN anonymization fix

### DIFF
--- a/open_ticket_ai/experimental/anonymize_data.py
+++ b/open_ticket_ai/experimental/anonymize_data.py
@@ -38,6 +38,12 @@ def anonymize_text(text):
             pass
         return num_str
     new_text = re.sub(r'\+?\d[\d\s\-\(\)]{7,}\d', replace_phone, new_text)
+    # IBAN erkennen und ersetzen
+    new_text = re.sub(
+        r"\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b",
+        lambda m: fake.iban(),
+        new_text,
+    )
     # (Optional) Einfache Erkennung von Adressen mit Straßenname und Nummer
     new_text = re.sub(
         r'\b[A-ZÄÖÜ][a-zäöüß]+(?:straße|Str\.|Weg|Platz)\s*\d+[a-zA-Z]?\b',

--- a/open_ticket_ai/tests/src/run/fetchers/test_fetchers.py
+++ b/open_ticket_ai/tests/src/run/fetchers/test_fetchers.py
@@ -1,0 +1,53 @@
+import pytest
+
+from open_ticket_ai.src.ce.run.fetchers.data_fetcher import DataFetcher
+from open_ticket_ai.src.ce.run.fetchers.basic_ticket_fetcher import BasicTicketFetcher
+from open_ticket_ai.src.ce.core.config.config_models import FetcherConfig
+
+
+class DummyFetcher(DataFetcher):
+    """Simple concrete implementation for testing."""
+
+    def fetch_data(self, *args, **kwargs):
+        return {"args": args, "kwargs": kwargs}
+
+
+def test_data_fetcher_is_abstract():
+    cfg = FetcherConfig(provider_key="dummy", id="f1")
+    with pytest.raises(TypeError):
+        DataFetcher(cfg)
+
+
+def test_data_fetcher_init_stores_config():
+    cfg = FetcherConfig(provider_key="dummy", id="f1")
+    fetcher = DummyFetcher(cfg)
+    assert fetcher.fetcher_config is cfg
+
+
+def test_data_fetcher_default_description():
+    cfg = FetcherConfig(provider_key="dummy", id="f1")
+    fetcher = DummyFetcher(cfg)
+    assert fetcher.get_description() == "No description provided."
+
+
+def test_dummy_fetcher_fetch_data_returns_dict():
+    cfg = FetcherConfig(provider_key="dummy", id="f1")
+    fetcher = DummyFetcher(cfg)
+    result = fetcher.fetch_data(1, key="value")
+    assert result == {"args": (1,), "kwargs": {"key": "value"}}
+
+
+def test_basic_ticket_fetcher_description():
+    cfg = FetcherConfig(provider_key="basic", id="basic1")
+    fetcher = BasicTicketFetcher(cfg)
+    expected = (
+        "Basic ticket fetcher that retrieves ticket data from a source. "
+        "It is a placeholder for a more complex implementation."
+    )
+    assert fetcher.get_description() == expected
+
+
+def test_basic_ticket_fetcher_fetch_data_returns_none():
+    cfg = FetcherConfig(provider_key="basic", id="basic1")
+    fetcher = BasicTicketFetcher(cfg)
+    assert fetcher.fetch_data() is None


### PR DESCRIPTION
## Summary
- anonymize IBANs in experimental anonymization utility
- add tests for DataFetcher and BasicTicketFetcher

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a726c8c0c8327bac7a87b78de6c22