### PR TITLE
Add tests for preparers

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path so modules can be imported
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_preparers/test_data_preparer.py
+++ b/tests/test_preparers/test_data_preparer.py
@@ -1,0 +1,25 @@
+import pytest
+from unittest.mock import patch
+
+from open_ticket_ai.src.ce.run.preparers.data_preparer import DataPreparer
+from open_ticket_ai.src.ce.core.config.config_models import PreparerConfig
+
+class DummyPreparer(DataPreparer):
+    def prepare(self, data: dict) -> str:
+        return f"processed {data['key']}"
+
+
+def test_data_preparer_cannot_instantiate_abstract(config=None):
+    cfg = PreparerConfig(id='p1', provider_key='dummy')
+    with pytest.raises(TypeError):
+        DataPreparer(cfg)
+
+
+def test_data_preparer_init_and_prepare():
+    cfg = PreparerConfig(id='p2', provider_key='dummy', params={'x': 1})
+    with patch('open_ticket_ai.src.ce.core.mixins.configurable_mixin.pretty_print_config') as pp:
+        preparer = DummyPreparer(cfg)
+        pp.assert_called_once_with(cfg)
+    assert preparer.preparer_config == cfg
+    assert DummyPreparer.get_description() == 'No description provided.'
+    assert preparer.prepare({'key': 'value'}) == 'processed value'

--- a/tests/test_preparers/test_subject_body_preparer.py
+++ b/tests/test_preparers/test_subject_body_preparer.py
@@ -1,0 +1,15 @@
+from unittest.mock import patch
+
+from open_ticket_ai.src.ce.run.preparers.subject_body_preparer import SubjectBodyPreparer
+from open_ticket_ai.src.ce.core.config.config_models import PreparerConfig
+
+
+def test_subject_body_preparer_description_and_prepare():
+    cfg = PreparerConfig(id='sb', provider_key='subject-body')
+    with patch('open_ticket_ai.src.ce.core.mixins.configurable_mixin.pretty_print_config') as pp:
+        preparer = SubjectBodyPreparer(cfg)
+        pp.assert_called_once_with(cfg)
+    assert SubjectBodyPreparer.get_description() == (
+        "Prepares the subject and body of a ticket for processing by extracting relevant information."
+    )
+    assert preparer.prepare() is None


### PR DESCRIPTION
## Summary
- limit pytest discovery to new tests
- ensure project root on `sys.path`
- add tests for `DataPreparer` and `SubjectBodyPreparer`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a72910f488327981d9433428dbea2