### PR TITLE
Add pytest tests for core mixins

### DIFF
--- a/open_ticket_ai/src/ce/core/mixins/test_configurable_mixin.py
+++ b/open_ticket_ai/src/ce/core/mixins/test_configurable_mixin.py
@@ -1,0 +1,94 @@
+import logging
+from unittest.mock import patch
+
+import pytest
+from pydantic import BaseModel
+
+from open_ticket_ai.src.ce.core.mixins.configurable_mixin import ConfigurableMixin
+
+
+class DummyConfig(BaseModel):
+    param_a: str
+    param_b: int
+
+
+class MyConfigurableClass(ConfigurableMixin):
+    def __init__(self, config: DummyConfig):
+        super().__init__(config)
+
+
+def test_configurable_mixin_logs_config():
+    """
+    Tests that ConfigurableMixin logs the class name and configuration
+    during initialization.
+    """
+    test_config = DummyConfig(param_a="test_value", param_b=123)
+
+    with patch.object(logging.getLogger("open_ticket_ai.src.ce.core.mixins.configurable_mixin"), "info") as mock_log_info, \
+         patch("open_ticket_ai.src.ce.core.mixins.configurable_mixin.pretty_print_config") as mock_pretty_print:
+
+        MyConfigurableClass(config=test_config)
+
+        assert mock_log_info.call_count == 1
+        mock_log_info.assert_any_call("Initializing MyConfigurableClass with config:")
+        mock_pretty_print.assert_called_once_with(test_config)
+
+
+def test_configurable_mixin_requires_config():
+    """
+    Tests that ConfigurableMixin (or a class using it) raises an error
+    if config is not provided, as per its __init__ signature.
+    """
+    with pytest.raises(TypeError) as excinfo:
+        MyConfigurableClass()  # type: ignore
+
+    assert "'config'" in str(excinfo.value)
+
+class AnotherConfigurable(ConfigurableMixin):
+    pass # No __init__ here, relies on Mixin's if not overridden
+
+
+def test_configurable_mixin_init_without_explicit_super_call():
+    """
+    Tests a class that inherits ConfigurableMixin but doesn't explicitly call super().__init__
+    in its own __init__. This scenario might not be typical for this mixin
+    but tests resilience.
+    """
+    class MinimalConfigurable(ConfigurableMixin):
+        def __init__(self, config: DummyConfig):
+            # Forgetting super().__init__(config)
+            # This test expects the mixin's __init__ NOT to be called.
+            # If the mixin's __init__ was essential for some internal state setup
+            # beyond logging, this test would need to verify that state.
+            # However, current ConfigurableMixin only logs.
+            pass
+
+    test_config = DummyConfig(param_a="minimal", param_b=0)
+    with patch.object(logging.getLogger("open_ticket_ai.src.ce.core.mixins.configurable_mixin"), "info") as mock_log_info:
+        MinimalConfigurable(config=test_config)
+        mock_log_info.assert_not_called()
+
+
+class ConfigurableWithOwnInitLogic(ConfigurableMixin):
+    def __init__(self, config: DummyConfig, extra_param: str):
+        super().__init__(config)
+        self.extra_param = extra_param
+        self.config_snapshot = config # Storing for later verification
+
+def test_configurable_mixin_with_subclass_init_logic():
+    """
+    Tests that ConfigurableMixin works correctly when the subclass has its
+    own __init__ logic and calls super().__init__ correctly.
+    """
+    test_config = DummyConfig(param_a="subclass_test", param_b=456)
+    extra_value = "extra_data"
+
+    with patch.object(logging.getLogger("open_ticket_ai.src.ce.core.mixins.configurable_mixin"), "info") as mock_log_info, \
+         patch("open_ticket_ai.src.ce.core.mixins.configurable_mixin.pretty_print_config") as mock_pretty_print:
+
+        instance = ConfigurableWithOwnInitLogic(config=test_config, extra_param=extra_value)
+
+        mock_log_info.assert_any_call("Initializing ConfigurableWithOwnInitLogic with config:")
+        mock_pretty_print.assert_called_once_with(test_config)
+        assert instance.extra_param == extra_value
+        assert instance.config_snapshot == test_config

--- a/open_ticket_ai/src/ce/core/mixins/test_description_mixin.py
+++ b/open_ticket_ai/src/ce/core/mixins/test_description_mixin.py
@@ -1,0 +1,64 @@
+import pytest
+
+from open_ticket_ai.src.ce.core.mixins.description_mixin import DescriptionMixin
+
+
+class DescribedClass(DescriptionMixin):
+    pass
+
+
+class CustomDescribedClass(DescriptionMixin):
+    @staticmethod
+    def get_description() -> str:
+        return "This is a custom description."
+
+
+def test_description_mixin_default_description():
+    """
+    Tests that a class using DescriptionMixin returns the default description
+    if get_description is not overridden.
+    """
+    assert DescribedClass.get_description() == "No description provided."
+    # Test instance access as well, though it's a static method
+    instance = DescribedClass()
+    assert instance.get_description() == "No description provided."
+
+
+def test_description_mixin_custom_description():
+    """
+    Tests that a class using DescriptionMixin can override the get_description
+    method to provide a custom description.
+    """
+    assert CustomDescribedClass.get_description() == "This is a custom description."
+    # Test instance access as well
+    instance = CustomDescribedClass()
+    assert instance.get_description() == "This is a custom description."
+
+
+def test_description_mixin_direct_call():
+    """
+    Tests calling get_description directly on the DescriptionMixin.
+    """
+    assert DescriptionMixin.get_description() == "No description provided."
+
+class AnotherDescribedClass(DescriptionMixin):
+    # No override
+    pass
+
+def test_description_mixin_multiple_classes():
+    """
+    Tests that multiple classes using DescriptionMixin work as expected,
+    one with default and one with custom description.
+    """
+    assert DescribedClass.get_description() == "No description provided."
+    assert CustomDescribedClass.get_description() == "This is a custom description."
+    assert AnotherDescribedClass.get_description() == "No description provided."
+
+    # Ensure they don't interfere
+    custom_instance = CustomDescribedClass()
+    default_instance = DescribedClass()
+    another_default_instance = AnotherDescribedClass()
+
+    assert custom_instance.get_description() == "This is a custom description."
+    assert default_instance.get_description() == "No description provided."
+    assert another_default_instance.get_description() == "No description provided."

--- a/open_ticket_ai/src/ce/core/mixins/test_registry_validation_mixin.py
+++ b/open_ticket_ai/src/ce/core/mixins/test_registry_validation_mixin.py
@@ -1,0 +1,95 @@
+import pytest
+from pydantic import ValidationError
+
+from open_ticket_ai.src.ce.core.mixins.registry_validation_mixin import Registerable
+
+
+def test_registerable_valid_provider_key():
+    """
+    Tests that Registerable model accepts a valid provider_key.
+    """
+    data = {"provider_key": "valid_key"}
+    reg = Registerable(**data)
+    assert reg.provider_key == "valid_key"
+
+
+def test_registerable_provider_key_is_required():
+    """
+    Tests that provider_key is a required field in Registerable model.
+    """
+    with pytest.raises(ValidationError) as excinfo:
+        Registerable()  # type: ignore
+    assert "provider_key" in str(excinfo.value)
+    # Pydantic v2 error messages have "Field required"
+    assert "Field required" in str(excinfo.value)
+
+
+def test_registerable_provider_key_min_length():
+    """
+    Tests that provider_key must have a minimum length of 1.
+    """
+    with pytest.raises(ValidationError) as excinfo:
+        Registerable(provider_key="")
+    assert "provider_key" in str(excinfo.value)
+    # Pydantic v2 message for min_length is "String should have at least %s characters"
+    # Using .lower() to make the check case-insensitive for "String".
+    assert "string should have at least 1 character" in str(excinfo.value).lower()
+
+
+def test_registerable_provider_key_various_valid_keys():
+    """
+    Tests Registerable with various valid provider_key values.
+    """
+    valid_keys = ["a", "1", "_", "long-provider-key_123"]
+    for key in valid_keys:
+        reg = Registerable(provider_key=key)
+        assert reg.provider_key == key
+
+
+def test_registerable_with_extra_fields():
+    """
+    Tests that Registerable model allows extra fields by default Pydantic behavior,
+    if not configured otherwise. The mixin itself doesn't restrict this.
+    """
+    data = {"provider_key": "valid_key", "extra_field": "some_value"}
+    # By default, Pydantic models ignore extra fields unless config forbids it.
+    # If this test fails, it might be due to global Pydantic settings or a
+    # future change in the Registerable model itself.
+    try:
+        reg = Registerable(**data)
+        assert reg.provider_key == "valid_key"
+        # Check if extra_field was ignored or accepted based on Pydantic version/config
+        # For default Pydantic V2, extra fields are ignored unless model_config has extra = 'allow'
+        assert not hasattr(reg, "extra_field")
+    except ValidationError:
+        # This would happen if extra fields were forbidden
+        pytest.fail("Registerable model unexpectedly raised ValidationError for extra fields.")
+
+class SubclassOfRegisterable(Registerable):
+    specific_field: int
+
+def test_subclass_of_registerable():
+    """
+    Tests that a subclass of Registerable correctly inherits and validates
+    the provider_key, and also handles its own fields.
+    """
+    # Valid case
+    data_valid = {"provider_key": "sub_key", "specific_field": 100}
+    sub_reg_valid = SubclassOfRegisterable(**data_valid)
+    assert sub_reg_valid.provider_key == "sub_key"
+    assert sub_reg_valid.specific_field == 100
+
+    # Invalid provider_key
+    data_invalid_provider = {"provider_key": "", "specific_field": 100}
+    with pytest.raises(ValidationError) as excinfo_provider:
+        SubclassOfRegisterable(**data_invalid_provider)
+    assert "provider_key" in str(excinfo_provider.value)
+    assert "string should have at least 1 character" in str(excinfo_provider.value).lower()
+
+
+    # Missing specific_field (should also fail)
+    data_missing_specific = {"provider_key": "sub_key_2"}
+    with pytest.raises(ValidationError) as excinfo_specific:
+        SubclassOfRegisterable(**data_missing_specific) # type: ignore
+    assert "specific_field" in str(excinfo_specific.value)
+    assert "field required" in str(excinfo_specific.value).lower()


### PR DESCRIPTION
This commit introduces pytest tests for the following core mixins:
- ConfigurableMixin
- DescriptionMixin
- Registerable (from registry_validation_mixin)

The tests cover basic functionality, edge cases, and validation as appropriate for each mixin. All added tests are passing.

Note: During testing, a warning indicated that the 'open-ticket-ai' package requires Python >=3.13. The current test environment uses Python 3.12.11. While the mixin tests pass with 3.12.11, full project functionality might depend on Python 3.13+.