### PR TITLE
Add Markdown translation script

### DIFF
--- a/open_ticket_ai/scripts/doc_generation/translate_docs.py
+++ b/open_ticket_ai/scripts/doc_generation/translate_docs.py
@@ -1,0 +1,77 @@
+import argparse
+import os
+from pathlib import Path
+from typing import List
+
+import requests
+
+
+API_URL = "https://openrouter.ai/api/v1/chat/completions"
+DEFAULT_MODEL = "meta-llama/llama-3-70b-instruct"
+DEFAULT_LANGUAGES = ["de", "en"]
+
+
+def translate_text(content: str, target_lang: str, model: str, api_key: str) -> str:
+    """Translate markdown *content* to *target_lang* using OpenRouter."""
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    data = {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "You are a helpful translator. Translate the user's markdown "
+                    "into the requested language while keeping markdown and YAML "
+                    "front matter intact."
+                ),
+            },
+            {
+                "role": "user",
+                "content": f"Translate the following markdown to {target_lang}:\n\n{content}",
+            },
+        ],
+        "temperature": 0.2,
+    }
+    response = requests.post(API_URL, headers=headers, json=data, timeout=60)
+    response.raise_for_status()
+    result = response.json()
+    return result["choices"][0]["message"]["content"]
+
+
+def process_file(path: Path, root: Path, languages: List[str], model: str, api_key: str, out_dir: Path) -> None:
+    """Translate a single Markdown *path* and write results under *out_dir*."""
+    text = path.read_text(encoding="utf-8")
+    relative = path.relative_to(root)
+    for lang in languages:
+        translated = translate_text(text, lang, model, api_key)
+        out_file = out_dir / lang / relative
+        out_file.parent.mkdir(parents=True, exist_ok=True)
+        out_file.write_text(translated, encoding="utf-8")
+        print(f"Wrote {out_file}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Translate Markdown documentation using OpenRouter")
+    parser.add_argument("--docs-dir", default="vitepress-atc-docs", help="Directory containing markdown docs")
+    parser.add_argument("--languages", default=",".join(DEFAULT_LANGUAGES), help="Comma separated target languages")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="OpenRouter model to use")
+    parser.add_argument("--out-dir", default="translated-docs", help="Base output directory for translations")
+
+    args = parser.parse_args()
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENROUTER_API_KEY environment variable not set")
+
+    docs_dir = Path(args.docs_dir)
+    out_dir = Path(args.out_dir)
+    languages = [l.strip() for l in args.languages.split(",") if l.strip()]
+
+    for md_file in docs_dir.rglob("*.md"):
+        process_file(md_file, docs_dir, languages, args.model, api_key, out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/open_ticket_ai/src/ce/core/__init__.py
+++ b/open_ticket_ai/src/ce/core/__init__.py
@@ -1,4 +1,18 @@
-from .dependency_injection.abstract_container import AbstractContainer
-from .dependency_injection.registry import Registry
-from .dependency_injection.create_registry import create_registry
-from .dependency_injection.container import DIContainer
+"""Lazy import helpers for dependency injection modules."""
+
+__all__ = ["AbstractContainer", "Registry", "create_registry", "DIContainer"]
+
+def __getattr__(name: str):
+    if name == "AbstractContainer":
+        from .dependency_injection.abstract_container import AbstractContainer
+        return AbstractContainer
+    if name == "Registry":
+        from .dependency_injection.registry import Registry
+        return Registry
+    if name == "create_registry":
+        from .dependency_injection.create_registry import create_registry
+        return create_registry
+    if name == "DIContainer":
+        from .dependency_injection.container import DIContainer
+        return DIContainer
+    raise AttributeError(name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "injector~=0.22.0",
     "schedule~=1.2.2",
     "otobo>=1.0.1",
+    "requests~=2.32.4",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ruff
 pytest
+requests~=2.32.4


### PR DESCRIPTION
## Summary
- add a script that translates vitepress docs using OpenRouter
- lazily load dependency injection objects to avoid circular imports
- include `requests` in dependencies

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a854531cc8327bdcdbbef1aac7c7c