### PR TITLE
Update core config tests for pipeline model

### DIFF
--- a/open_ticket_ai/src/ce/core/config/config_models.py
+++ b/open_ticket_ai/src/ce/core/config/config_models.py
@@ -87,5 +87,13 @@ class OpenTicketAIConfig(BaseModel):
 
 # load_config function remains the same
 def load_config(path: str) -> OpenTicketAIConfig:
-    # ... no change here
-    pass
+    """Load a YAML configuration file from ``path``."""
+    import yaml
+
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+
+    if "open_ticket_ai" not in data:
+        raise KeyError("Missing 'open_ticket_ai' root key")
+
+    return OpenTicketAIConfig(**data["open_ticket_ai"])

--- a/open_ticket_ai/tests/src/core/util_test.py
+++ b/open_ticket_ai/tests/src/core/util_test.py
@@ -33,13 +33,12 @@ def test_find_project_root_invalid_name_raises():
 
 # --- Tests for pretty_print_config.pretty_print_config ---
 
-def test_pretty_print_config_outputs_yaml(monkeypatch):
+def test_pretty_print_config_outputs_yaml():
     printed = []
     fake_console = SimpleNamespace(print=lambda x: printed.append(x))
-    monkeypatch.setattr(pretty_print_config, "console", fake_console)
 
     cfg = DummyModel(foo=1, bar="baz")
-    pretty_print_config.pretty_print_config(cfg)
+    pretty_print_config.pretty_print_config(cfg, fake_console)
 
     assert len(printed) == 1
     arg = printed[0]


### PR DESCRIPTION
## Summary
- add simple YAML config loader for OpenTicketAI
- migrate tests to new `PipelineConfig` model and scheduler setup
- adjust pretty print util test to accept console parameter

## Testing
- `pytest open_ticket_ai/tests/src/core -q`

------
https://chatgpt.com/codex/tasks/task_e_685acac48554832789ac676034bf777f