### PR TITLE
Add pipeline and orchestrator tests

### DIFF
--- a/open_ticket_ai/src/ce/run/orchestrator.py
+++ b/open_ticket_ai/src/ce/run/orchestrator.py
@@ -1,10 +1,15 @@
 """Top level orchestration utilities."""
+
 from __future__ import annotations
 
 import logging
 
+import schedule
+
 from open_ticket_ai.src.ce.core.config.config_models import OpenTicketAIConfig
-from open_ticket_ai.src.ce.core.dependency_injection.abstract_container import AbstractContainer
+from open_ticket_ai.src.ce.core.dependency_injection.abstract_container import (
+    AbstractContainer,
+)
 from open_ticket_ai.src.ce.run.pipeline.context import PipelineContext
 from open_ticket_ai.src.ce.run.pipeline.pipeline import Pipeline
 
@@ -16,8 +21,23 @@ class Orchestrator:
         self.config = config
         self.container = container
         self._logger = logging.getLogger(__name__)
+        self._pipelines: dict[str, Pipeline] = {}
 
-    def process_ticket(self, ticket_id: str,
-                       pipeline: Pipeline) -> PipelineContext:
+    def process_ticket(self, ticket_id: str, pipeline: Pipeline) -> PipelineContext:
         """Fetch data and run ``pipeline`` for ``ticket_id``."""
         return pipeline.execute(PipelineContext(ticket_id=ticket_id))
+
+    def build_pipelines(self) -> None:
+        """Instantiate pipeline objects using the DI container."""
+        for pipeline_cfg in self.config.pipelines:
+            self._pipelines[pipeline_cfg.id] = self.container.get_pipeline(pipeline_cfg.id)
+
+    def set_schedules(self) -> None:
+        """Schedule pipeline execution according to configuration."""
+        self.build_pipelines()
+        for pipeline_cfg in self.config.pipelines:
+            pipeline = self._pipelines[pipeline_cfg.id]
+            sched = getattr(
+                schedule.every(pipeline_cfg.schedule.interval), pipeline_cfg.schedule.unit
+            )
+            sched.do(pipeline.execute, PipelineContext(ticket_id=""))

--- a/open_ticket_ai/tests/test_orchestrator.py
+++ b/open_ticket_ai/tests/test_orchestrator.py
@@ -1,27 +1,31 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from pydantic import BaseModel
-
+import open_ticket_ai.src.ce.run.orchestrator as orchestrator_module
 from open_ticket_ai.src.ce.run.orchestrator import Orchestrator
-from open_ticket_ai.src.ce.run.pipeline.pipeline import Pipeline
+from open_ticket_ai.src.ce.run.pipeline.context import PipelineContext
 
 
-class DummyConfig(BaseModel):
-    pass
+def test_set_schedules_builds_and_schedules_pipelines(monkeypatch):
+    pipeline_cfg = SimpleNamespace(id="p1", schedule=SimpleNamespace(interval=5, unit="minutes"))
+    config = SimpleNamespace(pipelines=[pipeline_cfg])
 
+    pipeline_instance = MagicMock()
+    container = MagicMock(get_pipeline=MagicMock(return_value=pipeline_instance))
 
-def test_process_ticket_runs_pipeline():
-    fetcher = MagicMock()
-    fetcher.fetch_data.return_value = {"t": "data"}
-    pipeline = MagicMock(spec=Pipeline)
-    pipeline.execute.return_value = "result"
+    every_result = SimpleNamespace()
+    unit_result = MagicMock()
+    setattr(every_result, pipeline_cfg.schedule.unit, MagicMock(return_value=unit_result))
+    schedule_mock = MagicMock(every=MagicMock(return_value=every_result))
+    monkeypatch.setattr(orchestrator_module, "schedule", schedule_mock)
 
-    container = SimpleNamespace(get_fetcher=lambda fid: fetcher)
-    orch = Orchestrator(DummyConfig(), container)
+    orch = Orchestrator(config, container)
+    orch.set_schedules()
 
-    result = orch.process_ticket("T1", "fetcher_id", pipeline)
-
-    fetcher.fetch_data.assert_called_once_with(ticket_id="T1")
-    pipeline.execute.assert_called_once()
-    assert result == "result"
+    container.get_pipeline.assert_called_once_with("p1")
+    schedule_mock.every.assert_called_once_with(5)
+    getattr(every_result, pipeline_cfg.schedule.unit).assert_called_once()
+    unit_result.do.assert_called_once()
+    call_args = unit_result.do.call_args.args
+    assert call_args[0] == pipeline_instance.execute
+    assert isinstance(call_args[1], PipelineContext)

--- a/tests/src/run/pipeline/test_pipeline.py
+++ b/tests/src/run/pipeline/test_pipeline.py
@@ -1,0 +1,25 @@
+from unittest.mock import MagicMock
+
+from open_ticket_ai.src.ce.run.pipeline.context import PipelineContext
+from open_ticket_ai.src.ce.run.pipeline.pipe import Pipe
+from open_ticket_ai.src.ce.run.pipeline.pipeline import Pipeline
+
+
+def test_pipeline_executes_pipes_in_order():
+    ctx1 = PipelineContext(ticket_id="T1")
+
+    pipe1 = MagicMock(spec=Pipe)
+    ctx2 = PipelineContext(ticket_id="T1", data={"step": 1})
+    pipe1.process.return_value = ctx2
+
+    pipe2 = MagicMock(spec=Pipe)
+    ctx3 = PipelineContext(ticket_id="T1", data={"step": 2})
+    pipe2.process.return_value = ctx3
+
+    pipeline = Pipeline(config=MagicMock(), pipes=[pipe1, pipe2])
+
+    result = pipeline.execute(ctx1)
+
+    pipe1.process.assert_called_once_with(ctx1)
+    pipe2.process.assert_called_once_with(ctx2)
+    assert result == ctx3


### PR DESCRIPTION
## Summary
- add tests verifying Pipeline pipe ordering
- update Orchestrator with pipeline building and scheduling
- rewrite Orchestrator tests to cover new behaviour

## Testing
- `ruff check open_ticket_ai/src/ce/run/orchestrator.py`
- `ruff check tests/src/run/pipeline/test_pipeline.py open_ticket_ai/tests/test_orchestrator.py`
- `pytest tests/src/run/pipeline/test_pipeline.py open_ticket_ai/tests/test_orchestrator.py -q` *(fails: ModuleNotFoundError: No module named 'open_ticket_ai.src.ce.core.mixins.configurable_mixin')*

------
https://chatgpt.com/codex/tasks/task_e_685acae53c348327a3e180011af476fa