### PR TITLE
Add ProductsPriceTable component using Bootstrap

### DIFF
--- a/docs/vitepress/.vitepress/components/ProductsPriceTable.vue
+++ b/docs/vitepress/.vitepress/components/ProductsPriceTable.vue
@@ -1,0 +1,52 @@
+/**
+ * ProductsPriceTable renders a responsive table of projects with their prices
+ * and feature lists.
+ *
+ * @prop projects Array of objects containing `name`, `price` and `features`.
+ *
+ * @example
+ * ```vue
+ * <script setup lang="ts">
+ * import ProductsPriceTable from '.vitepress/components/ProductsPriceTable.vue'
+ *
+ * const projects = [
+ *   { name: 'Basic', price: 1000, features: ['Setup'] }
+ * ]
+ * </script>
+ *
+ * <div class="table-responsive">
+ *   <ProductsPriceTable :projects="projects" />
+ * </div>
+ * ```
+ */
+<template>
+  <table class="table table-striped table-hover">
+    <thead>
+      <tr>
+        <th scope="col">Name</th>
+        <th scope="col">Price</th>
+        <th scope="col">Features</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="(project, index) in projects" :key="index">
+        <td>{{ project.name }}</td>
+        <td>{{ formatPrice(project.price) }}</td>
+        <td>
+          <ul class="mb-0">
+            <li v-for="(f, idx) in project.features" :key="idx">{{ f }}</li>
+          </ul>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  projects: { name: string; price: number; features: string[] }[]
+}>()
+
+const formatPrice = (value: number): string =>
+  new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(value)
+</script>

--- a/docs/vitepress/.vitepress/config.mts
+++ b/docs/vitepress/.vitepress/config.mts
@@ -34,6 +34,13 @@ export default defineConfig({
         rel: 'icon',
         href: 'https://softoft.sirv.com/Images/atc-logo-2024-blue.png?w=300&q=100&lightness=100&colorlevel.white=100'
       }
+    ],
+    [
+      'link',
+      {
+        rel: 'stylesheet',
+        href: 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css'
+      }
     ]
   ],
   description: '',

--- a/docs/vitepress/docs-src/v1_1/en/index.md
+++ b/docs/vitepress/docs-src/v1_1/en/index.md
@@ -68,8 +68,19 @@ features:
       alt: "OTOBO ATC AI Icon"
 ---
 
-<script setup>
+<script setup lang="ts">
 import ATCPredictionDemo from './.vitepress/components/ATCPredictionDemo.vue'
+import ProductsPriceTable from './.vitepress/components/ProductsPriceTable.vue'
+
+const myProjects = [
+  { name: 'Basic',      price: 1000, features: ['Setup', '1 Attribute'] },
+  { name: 'Pro',        price: 9000, features: ['Fine-Tuning', '1 Attribute'] },
+  { name: 'Enterprise', price: 12000, features: ['Integrations', '3 Attributes'] },
+]
 </script>
 
 <ATCPredictionDemo/>
+
+<div class="table-responsive">
+  <ProductsPriceTable :projects="myProjects" />
+</div>


### PR DESCRIPTION
## Summary
- add ProductsPriceTable component using Vue Composition API and Bootstrap
- load Bootstrap CSS globally in VitePress config
- show component usage inside English index page

## Testing
- `npm run docs:build` *(fails: vitepress not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d64e431988327adb68dcf7a9eae51