### PR TITLE
Update SubjectBodyPreparer to use config params

### DIFF
--- a/open_ticket_ai/src/ce/run/pipe_implementations/subject_body_preparer.py
+++ b/open_ticket_ai/src/ce/run/pipe_implementations/subject_body_preparer.py
@@ -27,9 +27,9 @@ class SubjectBodyPreparer(Pipe):
     def process(self, context: PipelineContext) -> PipelineContext:
         """Processes ticket data to prepare subject and body content.
 
-        Extracts subject and body fields from context data, repeats the subject
-        as specified in configuration, and concatenates with the body. Stores
-        the result in context under 'prepared_data' key.
+        Extracts the configured subject and body fields from context data,
+        repeats the subject as specified in configuration, concatenates it with
+        the body and stores the result in the configured result field.
 
         Args:
             context (PipelineContext): Pipeline context containing ticket data.
@@ -39,13 +39,14 @@ class SubjectBodyPreparer(Pipe):
         """
         subject_field = self.preparer_config.params.get("subject_field", "subject")
         body_field = self.preparer_config.params.get("body_field", "body")
-        repeat_subject = int(self.preparer_config.params.get("repeat_subject", 1))
+        repeat_subject = int(self.preparer_config.params.get("repeat_subject", 3))
+        result_field = self.preparer_config.params.get("result_field", "subject_body_combined")
 
         subject = context.data.get(subject_field, "")
         body = context.data.get(body_field, "")
 
         prepared = f"{subject} " * repeat_subject + body
-        context.data["prepared_data"] = prepared.strip()
+        context.data[result_field] = prepared.strip()
         return context
 
     @staticmethod

--- a/open_ticket_ai/tests/src/run/test_preparers/test_subject_body_preparer.py
+++ b/open_ticket_ai/tests/src/run/test_preparers/test_subject_body_preparer.py
@@ -13,13 +13,25 @@ def test_subject_body_preparer_process_concatenates_fields():
     1. During initialization, the preparer calls pretty_print_config with its config
     2. The process method correctly concatenates 'subject' and 'body' fields from context data
     """
-    cfg = PreparerConfig(id="sb", provider_key="subject-body", params={})
+    cfg = PreparerConfig(
+        id="sb",
+        provider_key="subject-body",
+        params={
+            "subject_field": "subject",
+            "body_field": "body",
+            "repeat_subject": 3,
+            "result_field": "subject_body_combined",
+        },
+    )
     with patch(
         "open_ticket_ai.src.ce.core.mixins.registry_providable_instance.pretty_print_config"
     ) as pp:
         preparer = SubjectBodyPreparer(cfg)
         pp.assert_called_once()
         assert pp.call_args.args[0] is cfg
-    ctx = PipelineContext(ticket_id="1", data={"subject": "Hello", "body": "World"})
+    ctx = PipelineContext(
+        ticket_id="1",
+        data={"subject": "Hello", "body": "World"},
+    )
     result = preparer.process(ctx)
-    assert result.data["prepared_data"] == "Hello World"
+    assert result.data["subject_body_combined"] == "Hello Hello Hello World"


### PR DESCRIPTION
## Summary
- allow `SubjectBodyPreparer` to read `result_field` from config
- save prepared text under that result field
- update tests for new behaviour

## Testing
- `pytest open_ticket_ai/tests/src/run/test_preparers/test_subject_body_preparer.py::test_subject_body_preparer_process_concatenates_fields -q`
- `pytest -q` *(fails: Can't find model 'de_core_news_sm')*

------
https://chatgpt.com/codex/tasks/task_e_68614652e06c832784bcba5e3613bc82