### PR TITLE
Update architecture docs

### DIFF
--- a/docs/original_source/api/core/di.md
+++ b/docs/original_source/api/core/di.md
@@ -1,47 +1,18 @@
 ---
-description: Discover the Dependency Injection (DI) architecture of Open Ticket AI.
-  This documentation explains how to create and use a Python class registry to manage
-  core services like OTOBO integration, data preparation, and local Hugging Face AI
-  inference.
+description: Learn how Open Ticket AI uses dependency injection to assemble its components at startup.
 ---
-# Documentation for `**/ce/core/dependency_injection/**/*.py`
+# Dependency Injection
 
-## Module: `open_ticket_ai\src\ce\core\dependency_injection\abstract_container.py`
+Open Ticket AI relies on a small dependency injection (DI) container to build all
+required objects. Every component derives from the `Providable` mixin. The mixin
+exposes a `get_provider_key()` class method which is used to reference the
+component inside `config.yml`.
 
+During startup the CLI creates a `DIContainer`. The container loads
+`config.yml`, builds a `Registry` of all available classes and then instantiates
+components whose `provider_key` values appear in the configuration. Adding the
+name returned by `get_provider_key()` to the config is therefore enough to make a
+component available when the application starts.
 
-
----
-
-## Module: `open_ticket_ai\src\ce\core\dependency_injection\container.py`
-
-
-
----
-
-## Module: `open_ticket_ai\src\ce\core\dependency_injection\create_registry.py`
-
-
-
-### <span class='text-warning'>def</span> `create_registry() -> Registry`
-
-Creates and configures the default class registry.
-This function initializes a `Registry` instance and registers essential classes
-required for the application's dependency injection system. The registered classes
-include integration adapters, data preparers, and AI inference services.
-
-The following classes are registered:
-- `OTOBOAdapter`: Handles integration with the OTOBO ticket system.
-- `SubjectBodyPreparer`: Prepares subject and body content for ticket processing.
-- `HFLocalAIInferenceService`: Provides local AI inference using Hugging Face models.
-
-**Returns:** (`Registry`) - A configured registry instance with all necessary classes registered.
-
-
-
----
-
-## Module: `open_ticket_ai\src\ce\core\dependency_injection\registry.py`
-
-
-
----
+The container also offers helper methods such as `get_pipeline()` which creates a
+`Pipeline` instance by instantiating each listed pipe through the registry.

--- a/docs/original_source/api/main.md
+++ b/docs/original_source/api/main.md
@@ -7,6 +7,17 @@ description: Explore the documentation for the OpenTicketAI core engine. This gu
 ---
 # Documentation for `**/ce/*.py`
 
+## Starting the application
+
+Run the service from the command line:
+
+```bash
+python -m open_ticket_ai.src.ce.main start
+```
+
+This command initializes the dependency injection container and launches the
+configured pipelines.
+
 ## Module: `open_ticket_ai\src\ce\app.py`
 
 Main application module for OpenTicketAI.

--- a/docs/original_source/architecture.md
+++ b/docs/original_source/architecture.md
@@ -6,7 +6,33 @@ title: Open Ticket AI Architecture Overview
 ---
 # Architecture Overview
 
-Open Ticket AI is built around a modular pipeline that processes each ticket through a series of well-defined stages. The system relies on dependency injection and configuration files to assemble these stages, making it easy to extend or replace individual pieces.
+Open Ticket AI runs as a background service that is started from the command
+line.  Its architecture is built around a modular pipeline that processes each
+ticket through a series of well‑defined stages.  Dependency injection and a
+central configuration file (`config.yml`) control which components are used,
+making it easy to extend or replace individual pieces.
+
+## Application Entry Point
+
+Start the application with:
+
+```bash
+python -m open_ticket_ai.src.ce.main start
+```
+
+This command initializes the dependency injection container, constructs the
+`App` object and begins the main processing loop.
+
+## Execution Flow
+
+1. `main.py` configures logging and builds a `DIContainer`.
+2. The container loads `config.yml`, creating all configured components.
+3. The `App` validates the configuration and delegates to the
+   `Orchestrator`.
+4. The `Orchestrator` reads the pipeline definitions and schedules them using
+   the `schedule` library.
+5. Each scheduled pipeline periodically polls the help desk for new tickets and
+   processes them.
 
 ## Processing Pipeline
 

--- a/docs/original_source/concepts/mvp-technical-overview.md
+++ b/docs/original_source/concepts/mvp-technical-overview.md
@@ -24,16 +24,23 @@ These predicted queues and priorities can be mapped to your organization's speci
 
 ## Architecture Implementation
 
-The core of the MVP architecture is straightforward:
+The MVP uses the same pipeline architecture as the rest of Open Ticket AI.  A
+pipeline is defined in `config.yml` and lists the components that should run in
+order. Typical stages include a fetcher, data preparers, AI inference services
+and modifiers that write results back to the help desk.
 
-*   **`QueueClassifier` and `PriorityClassifier`:** These components load the specified Hugging Face models and execute them to predict queue and priority.
-*   **Mapping to Local Queues/Priorities:** The predictions from the models are then mapped to your local system's queues and priorities. This mapping is defined as a dictionary in the configuration file. You can use a wildcard character (`*`) to match any queue. It's common practice to have a "Miscellaneous" or "Junk" queue where wildcard matches are routed. The same wildcard logic applies to priorities, though it's less frequently needed given the typical 5-level priority scale.
-*   **`TicketClassifier`:** This component orchestrates the process by calling both the `QueueClassifier` and `PriorityClassifier` simultaneously and returning their combined results.
-*   **`TicketProcessor`:** This component is responsible for the overall workflow. It:
-    1.  Fetches the next ticket from the integrated ticket system (via the `TicketSystemAdapter`).
-    2.  Calls the `TicketClassifier` to get predictions.
-    3.  Calls the `updateTicket` method of its injected `TicketSystemAdapter` to apply the classification results to the ticket in the external system.
-    The `TicketProcessor` runs in a continuous loop, polling for new tickets at a configurable interval (defaulting to 10 seconds).
+Pipelines are executed by the `Orchestrator`, which schedules them at the
+interval specified in the configuration. Each pipeline polls the ticket system
+for new tickets and processes them through the configured pipes.
+
+Start the service with:
+
+```bash
+python -m open_ticket_ai.src.ce.main start
+```
+
+This command launches the CLI, loads `config.yml`, builds the dependency
+injection container and begins executing the pipelines.
 
 Below are some diagrams illustrating parts of the system design:
 

--- a/docs/original_source/concepts/pipeline-architecture.md
+++ b/docs/original_source/concepts/pipeline-architecture.md
@@ -28,6 +28,18 @@ The core of Open Ticket AI is its processing pipeline:
 
 Each stage in this pipeline consumes and produces **Value Objects** (e.g., `subject`, `body`, `queue_id`, `priority`). This design makes the pipeline modular and easy to extend with custom processing steps or new value objects.
 
+## Pipeline Components
+
+- **Pipeline** – A container that executes a sequence of pipes. It controls the
+  overall status and stops execution if any pipe reports a failure.
+- **Pipe** – A single processing step that implements a `process()` method.
+  Pipes inherit from the `Providable` mixin so they can be created from the
+  dependency injection container.
+- **PipelineContext** – A Pydantic model passed to every pipe. It stores the
+  ticket ID, arbitrary data produced by pipes and meta‑information such as the
+  current pipeline status. Pipes read from and write to this context object to
+  share data.
+
 ## System Diagrams
 
 ### Application Class Diagram


### PR DESCRIPTION
## Summary
- describe CLI entry point and execution flow in the architecture docs
- document pipeline components
- explain how to run the MVP service
- clarify the command-line start process in the API docs
- rewrite the DI docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68642b844a4083278067c1a79ef66963