### PR TITLE
Update installation and training docs

### DIFF
--- a/docs/original_source/get-started.md
+++ b/docs/original_source/get-started.md
@@ -1,29 +1,34 @@
 ---
-description: Learn how to quickly install Open Ticket AI using Docker. This guide
-  provides easy setup instructions for integrating with your OTRS, OTOBO, or Znuny
-  helpdesk via Web Services.
+description: Learn how to quickly install and run Open Ticket AI using Docker Compose. This guide provides easy setup instructions for integrating with your OTRS, OTOBO, or Znuny helpdesk via Web Services.
 title: Getting Started
 ---
+
 # Installation
 
-Open Ticket AI can be deployed quickly using Docker. Run the following command on your server to
-start the container:
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/your-org/open-ticket-ai.git
+   cd open-ticket-ai
+   ```
 
-```bash
-docker run -d your-docker-repo/atc:latest
-```
+2. **Copy the sample configuration**
+   ```bash
+   cp docs/original_source/_config_examples/queue_priority_local_config.yml config.yml
+   ```
 
-This community edition does **not** provide a public REST API. Instead, all communication happens
-via your ticket system's Web Services.
+3. **Build and start the services**
+   ```bash
+   docker-compose up -d --build
+   ```
+
+Open Ticket AI communicates with your ticket system via Web Services; there is no external API.
 
 # Ticket System Integration
 
-Currently integrations are available for **OTRS**, **OTOBO**, and **Znuny**. The setup is identical
-for all three systems:
+Currently integrations are available for **OTRS**, **OTOBO**, and **Znuny**. The setup is identical for all three systems:
 
 1. Configure the necessary Web Services in your ticket system.
 2. Create a dedicated user or agent for Open Ticket AI access.
 3. Point the integration to the URL and credentials of that Web Service user.
 
 For detailed instructions, consult the corresponding getting started guides for your ticket system.
-

--- a/docs/original_source/guide/hardware-requirements.md
+++ b/docs/original_source/guide/hardware-requirements.md
@@ -1,25 +1,27 @@
 ---
-description: Ensure peak performance for Open Ticket AI with the right hardware. This
-  guide details CPU, NVIDIA GPU, and RAM requirements for any ticket volume and deployment.
+description: Ensure peak performance for Open Ticket AI with the right hardware. This guide details CPU, GPU, and RAM recommendations for common deployment scenarios.
 title: Hardware Recommendations for Open Ticket AI
 ---
+
 # Hardware Recommendations
 
-Choosing the right hardware is important for the performance of Open Ticket AI, especially when dealing with a large volume of tickets or using more complex models.
+Selecting appropriate hardware ensures smooth operation of Open Ticket AI.
 
-*   **CPU-only**: Sufficient for small volumes of tickets (e.g., < 50 tickets per minute). Most modern server CPUs should handle this workload.
-*   **GPU (Graphics Processing Unit)**: Recommended for higher volumes (e.g., > 100 tickets per minute) or when using larger, more computationally intensive models. NVIDIA RTX series GPUs are a common choice.
-    *   **Examples**:
-        *   Hetzner Matrix GPU (which typically comes with ample vRAM)
-        *   AWS `g4ad.xlarge` instance or similar cloud GPU instances.
+* **CPU-only**: Adequate for small ticket volumes and models such as DistilBERT.
+* **GPU**: Recommended for high volumes or when using larger models. NVIDIA RTX series cards or comparable cloud instances (e.g., Hetzner Matrix GPU, AWS `g4ad.xlarge`) work well.
 
 ## Memory (RAM)
 
-Ensure you have enough RAM available for the models you intend to use. Refer to the [Training the Model](./training-models.md#4-model-selection-hardware) section for examples of RAM requirements for specific models.
+Approximate RAM requirements for the bundled models:
 
-*   For the default BERT models, you will generally need at least 4GB of RAM dedicated to the model, plus additional RAM for the operating system and the ticket system itself if they are running on the same host.
+| Model                | RAM |
+| -------------------- | --- |
+| DistilBERT           | ~2 GB |
+| BERT-base            | ~4 GB |
+
+Ensure additional RAM is available for the operating system and ticket system if they run on the same host.
 
 ## Deployment Considerations
 
-*   **Co-location vs. Separate Devices**: You can run Open Ticket AI on the same server as your ticket system or on a separate machine.
-*   **Network Configuration**: If running on separate devices, ensure your network configuration allows communication between Open Ticket AI and your ticket system. You will need to adjust the `rest_settings` (specifically the `base_url`) in your `config.yml` to point to the correct network address of your ticket system's API.
+* **Co-location vs. Separate Devices**: You can run Open Ticket AI on the same server as your ticket system or on a separate machine.
+* **Network Configuration**: If running on separate devices, adjust the `rest_settings.base_url` in `config.yml` so your ticket system can reach the application.

--- a/docs/original_source/guide/installation-guide.md
+++ b/docs/original_source/guide/installation-guide.md
@@ -1,29 +1,29 @@
 ---
-description: Install Open Ticket AI with our official guide. Learn to clone the repository,
-  create a configuration file, and launch the application using Docker Compose.
+description: Install Open Ticket AI with Docker Compose. This guide walks you through cloning the repository, creating a configuration file, and starting the application.
 title: Installing Open Ticket AI
 ---
+
 # Installation
 
-Follow these steps to install Open Ticket AI:
+The recommended way to deploy Open Ticket AI is via Docker Compose.
 
-1.  **Clone the repository**
-    ```bash
-    git clone https://github.com/your-org/open-ticket-ai.git
-    cd open-ticket-ai
-    ```
-
-2.  **Create a `config.yml`**
-    Refer to the [Configuration](../reference/configuration-reference.md) documentation for details on setting up this file.
-
-3.  **Start with Docker Compose**
-    This command will build the necessary Docker images and start the application services in detached mode.
-    ```bash
-    docker-compose up -d --build
-    ```
-
-4.  **Monitor logs**
-    You can monitor the logs of the running services to ensure everything is starting up correctly.
-    ```bash
-    docker-compose logs -f
-    ```
+1. **Ensure Docker and Docker Compose are installed** on your server.
+2. **Clone the repository**
+   ```bash
+   git clone https://github.com/your-org/open-ticket-ai.git
+   cd open-ticket-ai
+   ```
+3. **Create a configuration**
+   Copy the example configuration and modify it for your environment:
+   ```bash
+   cp docs/original_source/_config_examples/queue_priority_local_config.yml config.yml
+   ```
+4. **Start the services**
+   Build and launch the containers in the background:
+   ```bash
+   docker-compose up -d --build
+   ```
+5. **Monitor logs (optional)**
+   ```bash
+   docker-compose logs -f
+   ```

--- a/docs/original_source/guide/quickstart-guide.md
+++ b/docs/original_source/guide/quickstart-guide.md
@@ -1,75 +1,29 @@
 ---
-description: Discover how to easily install ATC using Docker and utilize its REST
-  API for automated support ticket classification. This guide provides step-by-step
-  instructions on sending training data, initiating model training, and classifying
-  new tickets to streamline your support workflow.
-title: Installation and Usage of ATC
+description: Quickstart guide for installing Open Ticket AI with Docker Compose and running the default workers.
+title: Open Ticket AI Quickstart
 ---
------------------------------------------------------------------------------------------------------
 
-# Installation of ATC
+# Quickstart
 
-ATC can be easily installed on your server using Docker. Follow the steps below to perform the installation:
+Follow these steps to get Open Ticket AI running with the sample configuration.
 
-## Step 1: Install Docker
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/your-org/open-ticket-ai.git
+   cd open-ticket-ai
+   ```
+2. **Copy the sample configuration**
+   ```bash
+   cp docs/original_source/_config_examples/queue_priority_local_config.yml config.yml
+   ```
+   Adjust `config.yml` with the URL and credentials of your ticket system.
+3. **Start the services**
+   ```bash
+   docker-compose up -d --build
+   ```
+4. **Monitor the logs (optional)**
+   ```bash
+   docker-compose logs -f
+   ```
 
-First, you need to install Docker on your server. Run the following commands to install Docker:
-
-```bash
-sudo apt-get update
-sudo apt-get install docker-ce docker-ce-cli containerd.io
-```
-
-## Step 2: Run the ATC Container
-
-After Docker is installed, you can run the ATC container. Use the following command to start the container:
-
-```bash
-docker run -d -p 8080:80 your-docker-repo/atc:latest
-```
-
-This command pulls the latest ATC Docker image from your repository and starts it on port 8080.
-
-# Using the ATC API
-
-After installation, you have HTTP REST access to the ATC API. Here are some basic commands to use the API:
-
-## Sending Training Data
-
-To send training data or a CSV file to the ATC REST API, use the following command:
-
-```bash
-curl -X POST http://your-server:8080/api/train \
-     -H "Content-Type: text/csv" \
-     --data-binary @yourfile.csv
-```
-
-This command sends the file `yourfile.csv` to the API for use in training.
-
-## Starting Training
-
-To start the model training, use this command:
-
-```bash
-curl -X POST http://your-server:8080/api/start-training
-```
-
-This command initiates the training process based on the previously sent data.
-
-## Classifying Tickets
-
-After successful training, you can send ticket data to the API for classification and receive the corresponding labels:
-
-```bash
-curl -X POST http://your-server:8080/api/classify \
-     -H "Content-Type: application/json" \
-     -d '{"ticket_data": "Your ticket content"}'
-```
-
-This command sends the ticket content for classification and returns the classification labels.
-
-# Summary
-
-With these steps, you can install ATC on your server and use the basic API functions. ATC offers a powerful, flexible solution for automated support ticket classification that is easy to install and use.
-
-This section describes the installation of ATC and the basic API commands in detail. You can adapt and extend it to include additional information or specific instructions.
+The queue and priority workers will automatically begin processing tickets based on your configuration.

--- a/docs/original_source/guide/training-models.md
+++ b/docs/original_source/guide/training-models.md
@@ -1,57 +1,19 @@
 ---
-description: Learn to train and fine-tune custom AI models for Open Ticket AI. This
-  guide covers essential steps from data collection and cleaning to hyperparameter
-  tuning and model evaluation to improve ticket queue and priority classification
-  accuracy.
-title: Training AI Models for Open Ticket AI
+description: Learn how to train or fine-tune your own models for Open Ticket AI. Training is performed outside of the application.
+title: Training Models
 ---
-# Training the Model
 
-:::note
-You only need to train your own model if you want to use a custom model or fine-tune the default models. To achieve good results, a significant amount of training data is necessary—ideally, at least 1000 tickets per queue and priority. Data cleaning, normalization, tokenization, and experimentation with different models and hyperparameters are often required.
-:::
+# Training Models
 
-Training or fine-tuning a model for Open Ticket AI involves several key steps:
+Open Ticket AI does not provide an in-app UI or API for model training. Instead, you train models externally and then reference them in your configuration.
 
-### 1. Data Collection
+## Workflow Overview
 
-*   **Export Historical Data**: Gather historical ticket data (including subject and body) from your existing ticket system.
-*   **Label Data**: Accurately label each ticket with the correct queue and priority. This labeled dataset will be the foundation for training your model.
-
-### 2. Data Cleaning
-
-*   **Remove Noise**: Eliminate irrelevant information such as email signatures, Personally Identifiable Information (PII), and spam.
-*   **Normalize Text**: Standardize whitespace and ensure consistent character encodings.
-
-### 3. Data Transformation & Tokenization
-
-*   **Combine Fields**: Concatenate the subject and body of the tickets to form a single input text for the model.
-*   **Set `max_length`**: Choose an appropriate `max_length` for tokenization (e.g., 256–512 tokens) based on the median length of your tickets. This prevents truncation of important information while managing computational resources.
-*   **Use Tokenizer**: Utilize the provided `ticket_combined_email_tokenizer` or a tokenizer compatible with your chosen model.
-
-### 4. Model Selection & Hardware
-
-Consider the following when selecting a model and the required hardware:
-
-| Model                          | RAM Required | Notes                         |
-| ------------------------------ | ------------ | ----------------------------- |
-| `distilbert-base-german-cased` | 2 GB         | Lightweight, German text      |
-| `bert-base-german-cased`       | 4 GB         | Higher accuracy, German text  |
-| `deberta-large-mnli`           | 8 GB         | Multilingual / large contexts |
-
-(*Note: The table above provides examples; actual requirements may vary.*)
-
-### 5. Training & Fine-Tuning
-
-*   **Hyperparameter Tuning**: Use the built-in hyperparameter tuner to experiment with settings like `learning_rate`, `batch_size`, and `epochs` to find the optimal configuration for your dataset.
-*   **Monitor Performance**: The training script will output a summary of the model's performance and resource usage, helping you track progress and make adjustments.
-
-### 6. Evaluation
-
-*   **Measure Accuracy**: Evaluate the model's performance based on its accuracy in predicting queue and priority.
-*   **Analyze Confidence**: Examine the relationship between the model's confidence scores and the correctness of its predictions. This analysis is crucial for setting an optimal `confidence_threshold` in the configuration.
-*   **Confidence-Weighted Accuracy Score (CWAS)** (Optional): You might consider using a metric like CWAS to get a more nuanced view of performance:
-    ```math
-    \text{CWAS} = \text{percent_predicted} \times (\text{percent_correct}^2)
-    ```
-    This score rewards models that are both accurate and make a high percentage of predictions (i.e., are not overly reliant on falling back to a default for low-confidence cases).
+1. **Export labeled tickets**
+   Export ticket texts with their queue and priority labels from your helpdesk.
+2. **Fine-tune a model**
+   Use a tool such as a Jupyter Notebook with the `transformers` library to train or fine-tune a language model on this data.
+3. **Publish or save the model**
+   Upload the resulting model to the Hugging Face Hub or save it locally so that Open Ticket AI can access it.
+4. **Update the configuration**
+   Edit `config.yml` and set the `model_name` (or `hf_model`) of each pipeline to the location of your new model. Restart the application to load it.


### PR DESCRIPTION
## Summary
- revamp **Getting Started** to clone the repo, copy `queue_priority_local_config.yml`, and run `docker-compose`
- streamline installation guide to only recommend Docker Compose
- rewrite quickstart for the sample configuration
- clarify that model training happens externally and adjust workflow
- update hardware recommendations for DistilBERT and BERT-base

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'phonenumbers')*

------
https://chatgpt.com/codex/tasks/task_e_68642b9681c083279dd1a00e0d0d32b3