### PR TITLE
Add developer extension guides and update configs

### DIFF
--- a/docs/original_source/_config_examples/config.schema.json
+++ b/docs/original_source/_config_examples/config.schema.json
@@ -1,85 +1,94 @@
 {
   "$defs": {
     "AIInferenceServiceConfig": {
-      "description": "Configuration for AI inference services.",
+      "description": "Configuration for AI inference services.\n\nThis class represents the configuration for an AI inference service component. It inherits all attributes\nfrom `ProvidableConfig`.",
       "properties": {
-        "provider_key": {
-          "minLength": 1,
-          "title": "Provider Key",
-          "type": "string"
-        },
         "id": {
+          "description": "The unique identifier for the registry instance.",
           "minLength": 1,
           "title": "Id",
           "type": "string"
         },
         "params": {
           "additionalProperties": true,
+          "description": "Additional parameters for the registry instance configuration.",
           "title": "Params",
           "type": "object"
+        },
+        "provider_key": {
+          "description": "The key identifying the provider for the registry instance.",
+          "minLength": 1,
+          "title": "Provider Key",
+          "type": "string"
         }
       },
       "required": [
-        "provider_key",
-        "id"
+        "id",
+        "provider_key"
       ],
       "title": "AIInferenceServiceConfig",
       "type": "object"
     },
     "FetcherConfig": {
-      "description": "Configuration for data fetchers.",
+      "description": "Configuration for data fetchers.\n\nThis class represents the configuration for a data fetcher component. It inherits all attributes\nfrom `ProvidableConfig`.",
       "properties": {
-        "provider_key": {
-          "minLength": 1,
-          "title": "Provider Key",
-          "type": "string"
-        },
         "id": {
+          "description": "The unique identifier for the registry instance.",
           "minLength": 1,
           "title": "Id",
           "type": "string"
         },
         "params": {
           "additionalProperties": true,
+          "description": "Additional parameters for the registry instance configuration.",
           "title": "Params",
           "type": "object"
+        },
+        "provider_key": {
+          "description": "The key identifying the provider for the registry instance.",
+          "minLength": 1,
+          "title": "Provider Key",
+          "type": "string"
         }
       },
       "required": [
-        "provider_key",
-        "id"
+        "id",
+        "provider_key"
       ],
       "title": "FetcherConfig",
       "type": "object"
     },
     "ModifierConfig": {
-      "description": "Configuration for modifiers.",
+      "description": "Configuration for modifiers.\n\nThis class represents the configuration for a modifier component. It inherits all attributes\nfrom `ProvidableConfig`.",
       "properties": {
-        "provider_key": {
-          "minLength": 1,
-          "title": "Provider Key",
-          "type": "string"
-        },
         "id": {
+          "description": "The unique identifier for the registry instance.",
           "minLength": 1,
           "title": "Id",
           "type": "string"
         },
         "params": {
           "additionalProperties": true,
+          "description": "Additional parameters for the registry instance configuration.",
           "title": "Params",
           "type": "object"
+        },
+        "provider_key": {
+          "description": "The key identifying the provider for the registry instance.",
+          "minLength": 1,
+          "title": "Provider Key",
+          "type": "string"
         }
       },
       "required": [
-        "provider_key",
-        "id"
+        "id",
+        "provider_key"
       ],
       "title": "ModifierConfig",
       "type": "object"
     },
     "OpenTicketAIConfig": {
-      "description": "Root configuration model for Open Ticket AI.",
+      "description": "Root configuration model for Open Ticket AI.\n\nAttributes:\n    system (SystemConfig): Configuration for the ticket system adapter.\n    fetchers (list[FetcherConfig]): List of data fetcher configurations. Must be non-empty.\n    data_preparers (list[PreparerConfig]): List of data preparer configurations. Must be non-empty.\n    ai_inference_services (list[AIInferenceServiceConfig]): List of AI inference service configurations. Must be non-empty.\n    modifiers (list[ModifierConfig]): List of modifier configurations. Must be non-empty.\n    pipelines (list[PipelineConfig]): List of pipeline configurations. Must be non-empty.",
       "properties": {
         "system": {
           "$ref": "#/$defs/SystemConfig"
@@ -137,11 +146,24 @@
       "type": "object"
     },
     "PipelineConfig": {
-      "description": "Configuration for a single pipeline workflow.",
+      "description": "Configuration for a single pipeline workflow.\n\nAttributes:\n    schedule (SchedulerConfig): The scheduling configuration for this pipeline.\n    pipes (list[str]): Ordered list of all pipe component IDs to execute, starting with a fetcher.\n        The list must have at least one element.",
       "properties": {
         "id": {
+          "description": "The unique identifier for the registry instance.",
           "minLength": 1,
           "title": "Id",
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": true,
+          "description": "Additional parameters for the registry instance configuration.",
+          "title": "Params",
+          "type": "object"
+        },
+        "provider_key": {
+          "description": "The key identifying the provider for the registry instance.",
+          "minLength": 1,
+          "title": "Provider Key",
           "type": "string"
         },
         "schedule": {
@@ -159,6 +181,7 @@
       },
       "required": [
         "id",
+        "provider_key",
         "schedule",
         "pipes"
       ],
@@ -166,33 +189,36 @@
       "type": "object"
     },
     "PreparerConfig": {
-      "description": "Configuration for data preparers.",
+      "description": "Configuration for data preparers.\n\nThis class represents the configuration for a data preparer component. It inherits all attributes\nfrom `ProvidableConfig`.",
       "properties": {
-        "provider_key": {
-          "minLength": 1,
-          "title": "Provider Key",
-          "type": "string"
-        },
         "id": {
+          "description": "The unique identifier for the registry instance.",
           "minLength": 1,
           "title": "Id",
           "type": "string"
         },
         "params": {
           "additionalProperties": true,
+          "description": "Additional parameters for the registry instance configuration.",
           "title": "Params",
           "type": "object"
+        },
+        "provider_key": {
+          "description": "The key identifying the provider for the registry instance.",
+          "minLength": 1,
+          "title": "Provider Key",
+          "type": "string"
         }
       },
       "required": [
-        "provider_key",
-        "id"
+        "id",
+        "provider_key"
       ],
       "title": "PreparerConfig",
       "type": "object"
     },
     "SchedulerConfig": {
-      "description": "Configuration for scheduling recurring tasks.",
+      "description": "Configuration for scheduling recurring tasks.\n\nAttributes:\n    interval (int): The interval of time to wait between runs. Must be at least 1.\n    unit (str): The unit of time for the interval (e.g., 'minutes', 'hours'). Must be non-empty.",
       "properties": {
         "interval": {
           "minimum": 1,
@@ -213,27 +239,35 @@
       "type": "object"
     },
     "SystemConfig": {
-      "description": "Configuration for the ticket system adapter.",
+      "description": "Configuration for the ticket system adapter.\n\nAttributes:\n    params (dict[str, Any]): A dictionary of parameters specific to the ticket system adapter.",
       "properties": {
-        "provider_key": {
+        "id": {
+          "description": "The unique identifier for the registry instance.",
           "minLength": 1,
-          "title": "Provider Key",
+          "title": "Id",
           "type": "string"
         },
         "params": {
           "additionalProperties": true,
           "title": "Params",
           "type": "object"
+        },
+        "provider_key": {
+          "description": "The key identifying the provider for the registry instance.",
+          "minLength": 1,
+          "title": "Provider Key",
+          "type": "string"
         }
       },
       "required": [
+        "id",
         "provider_key"
       ],
       "title": "SystemConfig",
       "type": "object"
     }
   },
-  "description": "Wrapper model used for schema generation.",
+  "description": "Wrapper model used for schema generation.\n\nThis class serves as a container for the main configuration model of the OpenTicketAI system.\nIt is designed to be used for generating JSON schema representations of the configuration.\n\nAttributes:\n    open_ticket_ai (OpenTicketAIConfig): The main configuration object containing all\n        settings and parameters for the OpenTicketAI system.",
   "properties": {
     "open_ticket_ai": {
       "$ref": "#/$defs/OpenTicketAIConfig"

--- a/docs/original_source/_config_examples/queue_priority_hf_endpoint_config.yml
+++ b/docs/original_source/_config_examples/queue_priority_hf_endpoint_config.yml
@@ -83,17 +83,18 @@ open_ticket_ai:
                 interval: 10
                 unit: "seconds"
             pipes:
-                - "basic_ticket_fetcher"
+                - "basic_ticket"
                 - "subject_body_preparer"
                 - "queue_ai_inference"
                 - "queue_updater"
 
         -   id: "priority_classification"
+            provider_key: "PriorityPredictor"
             schedule:
                 interval: 10
                 unit: "seconds"
             pipes:
-                - "basic_ticket_fetcher"
+                - "basic_ticket"
                 - "subject_body_preparer"
                 - "priority_ai_inference"
                 - "priority_updater"

--- a/docs/original_source/_config_examples/queue_priority_local_config.yml
+++ b/docs/original_source/_config_examples/queue_priority_local_config.yml
@@ -83,17 +83,18 @@ open_ticket_ai:
                 interval: 10
                 unit: "seconds"
             pipes:
-                - "basic_ticket_fetcher"
+                - "basic_ticket"
                 - "subject_body_preparer"
                 - "queue_ai_inference"
                 - "queue_updater"
 
         -   id: "priority_classification"
+            provider_key: "PriorityPredictor"
             schedule:
                 interval: 10
                 unit: "seconds"
             pipes:
-                - "basic_ticket_fetcher"
+                - "basic_ticket"
                 - "subject_body_preparer"
                 - "priority_ai_inference"
                 - "priority_updater"

--- a/docs/original_source/api/run/pipes.md
+++ b/docs/original_source/api/run/pipes.md
@@ -1,8 +1,7 @@
 ---
-description: Review the documentation for Python data models in `pipe_implementations`.
-  This guide details the `TextAIModelInput` class, used for structuring inputs for
-  AI text model inference, and the `EmptyDataModel`, a versatile Pydantic placeholder
-  for pipeline operations.
+description: Review the API for pipe implementations. See
+  the developer guide's "How to Add a Custom Pipe" section for
+  step-by-step instructions on creating your own pipe classes.
 ---
 # Documentation for `**/ce/run/pipe_implementations/*.py`
 

--- a/docs/original_source/api/run/ticket_system_integration.md
+++ b/docs/original_source/api/run/ticket_system_integration.md
@@ -1,9 +1,8 @@
 ---
-description: Explore the documentation for the Python `ticket_system_integration`
-  module. Learn how to use the `TicketSystemAdapter` abstract base class to create,
-  update, find, and manage tickets across different systems. This guide covers the
-  unified data models like `UnifiedTicket` and `UnifiedNote`, enabling a system-agnostic
-  approach to ticket management and integration.
+description: Explore the Python `ticket_system_integration` module.
+  The developer guide's "How to Integrate a New Ticket System" section
+  explains how to subclass `TicketSystemAdapter` and register new adapters.
+  This API reference documents the adapter base class and unified data models.
 ---
 # Documentation for `**/ce/ticket_system_integration/*.py`
 

--- a/docs/original_source/developer-information.md
+++ b/docs/original_source/developer-information.md
@@ -35,6 +35,70 @@ Direct training through the application is not provided in the MVP. Pre-trained 
 
 Custom fetchers, preparers, AI services, or modifiers can be implemented as Python classes and registered via the configuration. Thanks to dependency injection, new components can be easily integrated.
 
+## How to Add a Custom Pipe
+
+The processing pipeline can be extended with your own pipe classes. A pipe is a
+unit of work that receives a `PipelineContext`, modifies it and returns it. All
+pipes inherit from the [`Pipe`](../api/run/pipes.md) base class which already
+implements the `Providable` mixin.
+
+1. **Create a configuration model** for your pipe if it needs parameters.
+2. **Subclass `Pipe`** and implement the `process` method.
+3. **Override `get_provider_key()`** if you want a custom key.
+
+The following simplified example from the `AI_README` shows a sentiment analysis
+pipe:
+
+```python
+class SentimentPipeConfig(BaseModel):
+    model_name: str = "distilbert/distilbert-base-uncased-finetuned-sst-2-english"
+
+class SentimentAnalysisPipe(Pipe, Providable):
+    def __init__(self, config: SentimentPipeConfig):
+        super().__init__(config)
+        self.classifier = pipeline("sentiment-analysis", model=config.model_name)
+
+    def process(self, context: PipelineContext) -> PipelineContext:
+        ticket_text = context.data.get("combined_text")
+        if not ticket_text:
+            context.stop_pipeline()
+            return context
+
+        sentiment = self.classifier(ticket_text)[0]
+        context.data["sentiment"] = sentiment["label"]
+        context.data["sentiment_confidence"] = sentiment["score"]
+        return context
+
+    @classmethod
+    def get_provider_key(cls) -> str:
+        return "SentimentAnalysisPipe"
+```
+
+After implementing the class, register it in your dependency injection registry
+and reference it in `config.yml` using the provider key returned by
+`get_provider_key()`.
+
+## How to Integrate a New Ticket System
+
+To connect another help desk system, implement a new adapter that inherits from
+`TicketSystemAdapter`. The adapter converts between the external API and the
+project's unified models.
+
+1. **Create an adapter class**, e.g. `FreshdeskAdapter(TicketSystemAdapter)`.
+2. **Implement all abstract methods**:
+   - `find_tickets`
+   - `find_first_ticket`
+   - `create_ticket`
+   - `update_ticket`
+   - `add_note`
+3. **Translate data** to and from the `UnifiedTicket` and `UnifiedNote` models.
+4. **Provide a configuration model** for credentials or API settings.
+5. **Register the adapter** in `create_registry.py` so it can be instantiated
+   from the YAML configuration.
+
+Once registered, specify the adapter in the `system` section of `config.yml` and
+the orchestrator will use it to communicate with the ticket system.
+
 ## Summary
 
 The ATC Community Edition offers a locally executed workflow for automatic ticket classification in its MVP version. All settings are managed via YAML files; no REST API is available. External processes or scripts must be used for training.

--- a/open_ticket_ai/config.schema.json
+++ b/open_ticket_ai/config.schema.json
@@ -1,85 +1,94 @@
 {
   "$defs": {
     "AIInferenceServiceConfig": {
-      "description": "Configuration for AI inference services.",
+      "description": "Configuration for AI inference services.\n\nThis class represents the configuration for an AI inference service component. It inherits all attributes\nfrom `ProvidableConfig`.",
       "properties": {
-        "provider_key": {
-          "minLength": 1,
-          "title": "Provider Key",
-          "type": "string"
-        },
         "id": {
+          "description": "The unique identifier for the registry instance.",
           "minLength": 1,
           "title": "Id",
           "type": "string"
         },
         "params": {
           "additionalProperties": true,
+          "description": "Additional parameters for the registry instance configuration.",
           "title": "Params",
           "type": "object"
+        },
+        "provider_key": {
+          "description": "The key identifying the provider for the registry instance.",
+          "minLength": 1,
+          "title": "Provider Key",
+          "type": "string"
         }
       },
       "required": [
-        "provider_key",
-        "id"
+        "id",
+        "provider_key"
       ],
       "title": "AIInferenceServiceConfig",
       "type": "object"
     },
     "FetcherConfig": {
-      "description": "Configuration for data fetchers.",
+      "description": "Configuration for data fetchers.\n\nThis class represents the configuration for a data fetcher component. It inherits all attributes\nfrom `ProvidableConfig`.",
       "properties": {
-        "provider_key": {
-          "minLength": 1,
-          "title": "Provider Key",
-          "type": "string"
-        },
         "id": {
+          "description": "The unique identifier for the registry instance.",
           "minLength": 1,
           "title": "Id",
           "type": "string"
         },
         "params": {
           "additionalProperties": true,
+          "description": "Additional parameters for the registry instance configuration.",
           "title": "Params",
           "type": "object"
+        },
+        "provider_key": {
+          "description": "The key identifying the provider for the registry instance.",
+          "minLength": 1,
+          "title": "Provider Key",
+          "type": "string"
         }
       },
       "required": [
-        "provider_key",
-        "id"
+        "id",
+        "provider_key"
       ],
       "title": "FetcherConfig",
       "type": "object"
     },
     "ModifierConfig": {
-      "description": "Configuration for modifiers.",
+      "description": "Configuration for modifiers.\n\nThis class represents the configuration for a modifier component. It inherits all attributes\nfrom `ProvidableConfig`.",
       "properties": {
-        "provider_key": {
-          "minLength": 1,
-          "title": "Provider Key",
-          "type": "string"
-        },
         "id": {
+          "description": "The unique identifier for the registry instance.",
           "minLength": 1,
           "title": "Id",
           "type": "string"
         },
         "params": {
           "additionalProperties": true,
+          "description": "Additional parameters for the registry instance configuration.",
           "title": "Params",
           "type": "object"
+        },
+        "provider_key": {
+          "description": "The key identifying the provider for the registry instance.",
+          "minLength": 1,
+          "title": "Provider Key",
+          "type": "string"
         }
       },
       "required": [
-        "provider_key",
-        "id"
+        "id",
+        "provider_key"
       ],
       "title": "ModifierConfig",
       "type": "object"
     },
     "OpenTicketAIConfig": {
-      "description": "Root configuration model for Open Ticket AI.",
+      "description": "Root configuration model for Open Ticket AI.\n\nAttributes:\n    system (SystemConfig): Configuration for the ticket system adapter.\n    fetchers (list[FetcherConfig]): List of data fetcher configurations. Must be non-empty.\n    data_preparers (list[PreparerConfig]): List of data preparer configurations. Must be non-empty.\n    ai_inference_services (list[AIInferenceServiceConfig]): List of AI inference service configurations. Must be non-empty.\n    modifiers (list[ModifierConfig]): List of modifier configurations. Must be non-empty.\n    pipelines (list[PipelineConfig]): List of pipeline configurations. Must be non-empty.",
       "properties": {
         "system": {
           "$ref": "#/$defs/SystemConfig"
@@ -137,11 +146,24 @@
       "type": "object"
     },
     "PipelineConfig": {
-      "description": "Configuration for a single pipeline workflow.",
+      "description": "Configuration for a single pipeline workflow.\n\nAttributes:\n    schedule (SchedulerConfig): The scheduling configuration for this pipeline.\n    pipes (list[str]): Ordered list of all pipe component IDs to execute, starting with a fetcher.\n        The list must have at least one element.",
       "properties": {
         "id": {
+          "description": "The unique identifier for the registry instance.",
           "minLength": 1,
           "title": "Id",
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": true,
+          "description": "Additional parameters for the registry instance configuration.",
+          "title": "Params",
+          "type": "object"
+        },
+        "provider_key": {
+          "description": "The key identifying the provider for the registry instance.",
+          "minLength": 1,
+          "title": "Provider Key",
           "type": "string"
         },
         "schedule": {
@@ -159,6 +181,7 @@
       },
       "required": [
         "id",
+        "provider_key",
         "schedule",
         "pipes"
       ],
@@ -166,33 +189,36 @@
       "type": "object"
     },
     "PreparerConfig": {
-      "description": "Configuration for data preparers.",
+      "description": "Configuration for data preparers.\n\nThis class represents the configuration for a data preparer component. It inherits all attributes\nfrom `ProvidableConfig`.",
       "properties": {
-        "provider_key": {
-          "minLength": 1,
-          "title": "Provider Key",
-          "type": "string"
-        },
         "id": {
+          "description": "The unique identifier for the registry instance.",
           "minLength": 1,
           "title": "Id",
           "type": "string"
         },
         "params": {
           "additionalProperties": true,
+          "description": "Additional parameters for the registry instance configuration.",
           "title": "Params",
           "type": "object"
+        },
+        "provider_key": {
+          "description": "The key identifying the provider for the registry instance.",
+          "minLength": 1,
+          "title": "Provider Key",
+          "type": "string"
         }
       },
       "required": [
-        "provider_key",
-        "id"
+        "id",
+        "provider_key"
       ],
       "title": "PreparerConfig",
       "type": "object"
     },
     "SchedulerConfig": {
-      "description": "Configuration for scheduling recurring tasks.",
+      "description": "Configuration for scheduling recurring tasks.\n\nAttributes:\n    interval (int): The interval of time to wait between runs. Must be at least 1.\n    unit (str): The unit of time for the interval (e.g., 'minutes', 'hours'). Must be non-empty.",
       "properties": {
         "interval": {
           "minimum": 1,
@@ -213,27 +239,35 @@
       "type": "object"
     },
     "SystemConfig": {
-      "description": "Configuration for the ticket system adapter.",
+      "description": "Configuration for the ticket system adapter.\n\nAttributes:\n    params (dict[str, Any]): A dictionary of parameters specific to the ticket system adapter.",
       "properties": {
-        "provider_key": {
+        "id": {
+          "description": "The unique identifier for the registry instance.",
           "minLength": 1,
-          "title": "Provider Key",
+          "title": "Id",
           "type": "string"
         },
         "params": {
           "additionalProperties": true,
           "title": "Params",
           "type": "object"
+        },
+        "provider_key": {
+          "description": "The key identifying the provider for the registry instance.",
+          "minLength": 1,
+          "title": "Provider Key",
+          "type": "string"
         }
       },
       "required": [
+        "id",
         "provider_key"
       ],
       "title": "SystemConfig",
       "type": "object"
     }
   },
-  "description": "Wrapper model used for schema generation.",
+  "description": "Wrapper model used for schema generation.\n\nThis class serves as a container for the main configuration model of the OpenTicketAI system.\nIt is designed to be used for generating JSON schema representations of the configuration.\n\nAttributes:\n    open_ticket_ai (OpenTicketAIConfig): The main configuration object containing all\n        settings and parameters for the OpenTicketAI system.",
   "properties": {
     "open_ticket_ai": {
       "$ref": "#/$defs/OpenTicketAIConfig"


### PR DESCRIPTION
## Summary
- document how to add custom pipes and ticket system adapters
- highlight new developer sections in API docs
- fix example configs and regenerate schema

## Testing
- `python -m open_ticket_ai.src.ce.core.util.create_json_config_schema`
- `python - <<'EOF'
from open_ticket_ai.src.ce.core.config.config_models import load_config
load_config('docs/original_source/_config_examples/queue_priority_local_config.yml')
load_config('docs/original_source/_config_examples/queue_priority_hf_endpoint_config.yml')
print('ok')
EOF`
- `pytest -q` *(fails: ModuleNotFoundError: phonenumbers)*

------
https://chatgpt.com/codex/tasks/task_e_68642ba47b6483279cd1995b85a3f266