### PR TITLE
Add Storybook stories for Vitepress components

### DIFF
--- a/docs/vitepress_docs/stories/Accordion.stories.ts
+++ b/docs/vitepress_docs/stories/Accordion.stories.ts
@@ -1,0 +1,26 @@
+import Accordion from '../.vitepress/components/core/Accordion.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof Accordion> = {
+  title: 'Core/Accordion',
+  component: Accordion,
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const sampleItems = [
+  { title: 'Item 1', content: 'Content of item 1' },
+  { title: 'Item 2', content: 'Content of item 2' },
+]
+
+export const Default: Story = {
+  render: (args) => ({
+    components: { Accordion },
+    setup() { return { args } },
+    template: '<Accordion v-bind="args" />',
+  }),
+  args: {
+    items: sampleItems,
+  },
+}

--- a/docs/vitepress_docs/stories/Badge.stories.ts
+++ b/docs/vitepress_docs/stories/Badge.stories.ts
@@ -1,0 +1,31 @@
+import Badge from '../.vitepress/components/core/Badge.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof Badge> = {
+  title: 'Core/Badge',
+  component: Badge,
+  argTypes: {
+    type: { control: { type: 'select' }, options: ['primary','secondary','success','warning','danger'] }
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {
+  render: (args) => ({
+    components: { Badge },
+    setup() { return { args } },
+    template: '<Badge v-bind="args">Primary</Badge>'
+  }),
+  args: { type: 'primary' }
+}
+
+export const Success: Story = {
+  render: (args) => ({
+    components: { Badge },
+    setup() { return { args } },
+    template: '<Badge v-bind="args">Success</Badge>'
+  }),
+  args: { type: 'success' }
+}

--- a/docs/vitepress_docs/stories/Button.stories.ts
+++ b/docs/vitepress_docs/stories/Button.stories.ts
@@ -1,0 +1,32 @@
+import Button from '../.vitepress/components/core/Button.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof Button> = {
+  title: 'Core/Button',
+  component: Button,
+  argTypes: {
+    variant: { control: { type: 'select' }, options: ['primary', 'secondary'] },
+    disabled: { control: 'boolean' }
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {
+  render: (args) => ({
+    components: { Button },
+    setup() { return { args } },
+    template: '<Button v-bind="args">Primary Button</Button>'
+  }),
+  args: { variant: 'primary', disabled: false }
+}
+
+export const Secondary: Story = {
+  render: (args) => ({
+    components: { Button },
+    setup() { return { args } },
+    template: '<Button v-bind="args">Secondary Button</Button>'
+  }),
+  args: { variant: 'secondary', disabled: false }
+}

--- a/docs/vitepress_docs/stories/Callout.stories.ts
+++ b/docs/vitepress_docs/stories/Callout.stories.ts
@@ -1,0 +1,31 @@
+import Callout from '../.vitepress/components/core/Callout.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof Callout> = {
+  title: 'Core/Callout',
+  component: Callout,
+  argTypes: {
+    type: { control: { type: 'select' }, options: ['info','success','warning','danger'] }
+  }
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Info: Story = {
+  render: (args) => ({
+    components: { Callout },
+    setup() { return { args } },
+    template: '<Callout v-bind="args">Informational message</Callout>'
+  }),
+  args: { type: 'info' }
+}
+
+export const Danger: Story = {
+  render: (args) => ({
+    components: { Callout },
+    setup() { return { args } },
+    template: '<Callout v-bind="args">Danger message</Callout>'
+  }),
+  args: { type: 'danger' }
+}

--- a/docs/vitepress_docs/stories/Card.stories.ts
+++ b/docs/vitepress_docs/stories/Card.stories.ts
@@ -1,0 +1,18 @@
+import Card from '../.vitepress/components/core/Card.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof Card> = {
+  title: 'Core/Card',
+  component: Card,
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: (args) => ({
+    components: { Card },
+    setup() { return { args } },
+    template: '<Card>Simple card content</Card>'
+  }),
+}

--- a/docs/vitepress_docs/stories/CodeDocumentation.stories.ts
+++ b/docs/vitepress_docs/stories/CodeDocumentation.stories.ts
@@ -1,0 +1,32 @@
+import CodeDocumentation from '../.vitepress/components/CodeDocumentation.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof CodeDocumentation> = {
+  title: 'Components/CodeDocumentation',
+  component: CodeDocumentation,
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const PackageView: Story = {
+  render: (args) => ({
+    components: { CodeDocumentation },
+    setup() { return { args } },
+    template: '<CodeDocumentation v-bind="args" />'
+  }),
+  args: {
+    packageId: 'scripts.doc_generation'
+  }
+}
+
+export const ClassView: Story = {
+  render: (args) => ({
+    components: { CodeDocumentation },
+    setup() { return { args } },
+    template: '<CodeDocumentation v-bind="args" />'
+  }),
+  args: {
+    classId: 'scripts.doc_generation.add_docstrings.DocstringGenerator'
+  }
+}

--- a/docs/vitepress_docs/stories/ContactFormModal.stories.ts
+++ b/docs/vitepress_docs/stories/ContactFormModal.stories.ts
@@ -1,0 +1,24 @@
+import ContactFormModal from '../.vitepress/components/ContactFormModal.vue'
+import Button from '../.vitepress/components/core/Button.vue'
+import { ref } from 'vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof ContactFormModal> = {
+  title: 'Components/ContactFormModal',
+  component: ContactFormModal,
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: (args) => ({
+    components: { ContactFormModal, Button },
+    setup() {
+      const visible = ref(true)
+      return { args, visible }
+    },
+    template: '<ContactFormModal v-if="visible" v-bind="args" />'
+  }),
+  args: { plan: 'Professional' }
+}

--- a/docs/vitepress_docs/stories/Docstring.stories.ts
+++ b/docs/vitepress_docs/stories/Docstring.stories.ts
@@ -1,0 +1,28 @@
+import Docstring from '../.vitepress/components/Docstring.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof Docstring> = {
+  title: 'Components/Docstring',
+  component: Docstring,
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const sampleDoc = {
+  short_description: 'Example function',
+  long_description: 'This is a long description for the example function.',
+  params: [
+    { name: 'foo', type: 'string', description: 'Foo parameter' }
+  ],
+  returns: { type: 'number', description: 'Return value' }
+}
+
+export const Default: Story = {
+  render: (args) => ({
+    components: { Docstring },
+    setup() { return { args } },
+    template: '<Docstring v-bind="args" />'
+  }),
+  args: { doc: sampleDoc }
+}

--- a/docs/vitepress_docs/stories/FeatureGrid.stories.ts
+++ b/docs/vitepress_docs/stories/FeatureGrid.stories.ts
@@ -1,0 +1,24 @@
+import FeatureGrid from '../.vitepress/components/core/FeatureGrid.vue'
+import Card from '../.vitepress/components/core/Card.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof FeatureGrid> = {
+  title: 'Core/FeatureGrid',
+  component: FeatureGrid,
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => ({
+    components: { FeatureGrid, Card },
+    template: `
+      <FeatureGrid>
+        <Card>Feature 1</Card>
+        <Card>Feature 2</Card>
+        <Card>Feature 3</Card>
+      </FeatureGrid>
+    `,
+  }),
+}

--- a/docs/vitepress_docs/stories/FunctionDoc.stories.ts
+++ b/docs/vitepress_docs/stories/FunctionDoc.stories.ts
@@ -1,0 +1,29 @@
+import FunctionDoc from '../.vitepress/components/FunctionDoc.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof FunctionDoc> = {
+  title: 'Components/FunctionDoc',
+  component: FunctionDoc,
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const sampleFunc = {
+  name: 'add',
+  signature: '(a: number, b: number) => number',
+  docstring: {
+    short_description: 'Adds two numbers',
+    long_description: 'Returns the sum of a and b.'
+  },
+  is_async: false
+}
+
+export const Default: Story = {
+  render: (args) => ({
+    components: { FunctionDoc },
+    setup() { return { args } },
+    template: '<FunctionDoc v-bind="args" />'
+  }),
+  args: { func: sampleFunc }
+}

--- a/docs/vitepress_docs/stories/OTAIPredictionDemo.stories.ts
+++ b/docs/vitepress_docs/stories/OTAIPredictionDemo.stories.ts
@@ -1,0 +1,17 @@
+import OTAIPredictionDemo from '../.vitepress/components/OTAIPredictionDemo.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof OTAIPredictionDemo> = {
+  title: 'Components/OTAIPredictionDemo',
+  component: OTAIPredictionDemo,
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => ({
+    components: { OTAIPredictionDemo },
+    template: '<OTAIPredictionDemo />'
+  })
+}

--- a/docs/vitepress_docs/stories/ProductCards.stories.ts
+++ b/docs/vitepress_docs/stories/ProductCards.stories.ts
@@ -1,0 +1,38 @@
+import ProductCards from '../.vitepress/components/ProductCards.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof ProductCards> = {
+  title: 'Components/ProductCards',
+  component: ProductCards,
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const sampleProducts = [
+  {
+    name: 'Basic',
+    price: 10,
+    description: 'Basic plan',
+    features: [ { text: 'Feature 1', icon: '⭐' } ]
+  },
+  {
+    name: 'Pro',
+    price: 20,
+    description: 'Pro plan',
+    features: [ { text: 'Feature 2', icon: '🚀' } ],
+    featured: true
+  }
+]
+
+export const Default: Story = {
+  render: (args) => ({
+    components: { ProductCards },
+    setup() { return { args } },
+    template: '<ProductCards v-bind="args" />'
+  }),
+  args: {
+    products: sampleProducts,
+    title: 'Our Plans'
+  }
+}

--- a/docs/vitepress_docs/stories/ServicePackagesComponent.stories.ts
+++ b/docs/vitepress_docs/stories/ServicePackagesComponent.stories.ts
@@ -1,0 +1,17 @@
+import ServicePackagesComponent from '../.vitepress/components/ServicePackagesComponent.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof ServicePackagesComponent> = {
+  title: 'Components/ServicePackagesComponent',
+  component: ServicePackagesComponent,
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => ({
+    components: { ServicePackagesComponent },
+    template: '<ServicePackagesComponent />'
+  })
+}

--- a/docs/vitepress_docs/stories/SupportPlansComponent.stories.ts
+++ b/docs/vitepress_docs/stories/SupportPlansComponent.stories.ts
@@ -1,0 +1,17 @@
+import SupportPlansComponent from '../.vitepress/components/SupportPlansComponent.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof SupportPlansComponent> = {
+  title: 'Components/SupportPlansComponent',
+  component: SupportPlansComponent,
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => ({
+    components: { SupportPlansComponent },
+    template: '<SupportPlansComponent />'
+  })
+}

--- a/docs/vitepress_docs/stories/Tabs.stories.ts
+++ b/docs/vitepress_docs/stories/Tabs.stories.ts
@@ -1,0 +1,25 @@
+import Tabs from '../.vitepress/components/core/Tabs.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof Tabs> = {
+  title: 'Core/Tabs',
+  component: Tabs,
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const Template = (args:any) => ({
+  components: { Tabs },
+  setup() { return { args } },
+  template: `
+    <Tabs v-bind="args">
+      <template #tab-0>Content for first tab</template>
+      <template #tab-1>Content for second tab</template>
+    </Tabs>`
+})
+
+export const Default: Story = {
+  render: Template,
+  args: { tabs: ['First', 'Second'] }
+}


### PR DESCRIPTION
## Summary
- add new `/stories` folder under `docs/vitepress_docs`
- create Storybook stories for all Vue components in the Vitepress docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6868fb3c8f648327bdccf791fb8a2594