### PR TITLE
Fix pipeline scheduling closure and add orchestrator tests

### DIFF
--- a/open_ticket_ai/src/core/orchestrator.py
+++ b/open_ticket_ai/src/core/orchestrator.py
@@ -3,15 +3,15 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 import schedule
 
 from open_ticket_ai.src.core.config.config_models import OpenTicketAIConfig
-from open_ticket_ai.src.core.dependency_injection.abstract_container import (
-    AbstractContainer,
-)
 from open_ticket_ai.src.core.pipeline.context import PipelineContext
-from open_ticket_ai.src.core.pipeline.pipeline import Pipeline
+
+if TYPE_CHECKING:  # pragma: no cover - imported only for type hints
+    from open_ticket_ai.src.core.pipeline.pipeline import Pipeline
 
 
 class Orchestrator:
@@ -22,9 +22,22 @@ class Orchestrator:
 
     def set_schedules(self) -> None:
         for pipeline in self.pipelines:
-            def pipeline_job():
+            def pipeline_job(pipeline=pipeline) -> None:
+                """Execute the provided pipeline within a new context.
+
+                Using the loop variable directly inside the nested function would
+                cause all scheduled jobs to reference the *same* pipeline
+                instance (the last one from the loop) due to Python's late
+                binding behaviour for closures.  By capturing the current
+                pipeline as a default argument we ensure each job keeps a
+                reference to the pipeline it was created for.
+                """
+
                 pipeline.execute(PipelineContext())
 
-            schedule.every(pipeline.config.schedule.interval).__getattribute__(pipeline.config.schedule.unit).do(
-                pipeline_job
-            )
+            # Look up the scheduling unit dynamically (e.g. ``seconds``,
+            # ``minutes``) and register the job.
+            getattr(
+                schedule.every(pipeline.config.schedule.interval),
+                pipeline.config.schedule.unit,
+            ).do(pipeline_job)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,69 @@
+"""Unit tests for the :mod:`orchestrator` module."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import schedule
+
+from pathlib import Path
+import sys
+
+# Ensure the project root is on the import path so the ``open_ticket_ai``
+# package can be imported when tests are executed from the ``tests`` directory.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from open_ticket_ai.src.core.orchestrator import Orchestrator
+from open_ticket_ai.src.core.pipeline.context import PipelineContext
+
+
+def _make_pipeline(interval: int, unit: str) -> MagicMock:
+    """Create a mock pipeline with a minimal schedule configuration."""
+
+    pipeline = MagicMock()
+    pipeline.config = SimpleNamespace(
+        schedule=SimpleNamespace(interval=interval, unit=unit)
+    )
+    return pipeline
+
+
+def test_set_schedules_runs_each_pipeline_once() -> None:
+    """Each pipeline should be scheduled independently."""
+
+    schedule.clear()
+    p1 = _make_pipeline(1, "seconds")
+    p2 = _make_pipeline(1, "seconds")
+
+    orchestrator = Orchestrator(pipelines=[p1, p2], config=MagicMock())
+    orchestrator.set_schedules()
+
+    # Two jobs should be registered, one for each pipeline
+    assert len(schedule.get_jobs()) == 2
+
+    schedule.run_all(delay_seconds=0)
+
+    assert p1.execute.call_count == 1
+    assert p2.execute.call_count == 1
+
+
+def test_set_schedules_passes_pipeline_context_and_config() -> None:
+    """Scheduled jobs should honour the interval/unit and supply a context."""
+
+    schedule.clear()
+    pipeline = _make_pipeline(2, "minutes")
+
+    orchestrator = Orchestrator(pipelines=[pipeline], config=MagicMock())
+    orchestrator.set_schedules()
+
+    # Verify job was configured correctly
+    job = schedule.get_jobs()[0]
+    assert job.interval == 2
+    assert job.unit == "minutes"
+
+    schedule.run_all(delay_seconds=0)
+
+    # Pipeline receives a PipelineContext instance
+    (context,), _ = pipeline.execute.call_args
+    assert isinstance(context, PipelineContext)
+
+    schedule.clear()
+


### PR DESCRIPTION
## Summary
- Fix `Orchestrator.set_schedules` to bind each pipeline in its own scheduled job and remove unnecessary imports
- Add unit tests for `Orchestrator` ensuring jobs execute their respective pipelines and use provided scheduling config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5d58c7da88327b43999b77e267ba6