### PR TITLE
Add config unit tests and improve validator

### DIFF
--- a/open_ticket_ai/src/core/config/config_validator.py
+++ b/open_ticket_ai/src/core/config/config_validator.py
@@ -16,9 +16,13 @@ class OpenTicketAIConfigValidator:
         configs = self.config.get_all_register_instance_configs()
         for config in configs:
             if not self.registry.contains(config.provider_key):
-                raise ValueError(cleandoc(f"""
-                    Registry does not contain required Provider with id
-                    '{config.id}'
-                    There are following registered providers
-                    {self.registry.get_registry_types_descriptions()}
-                    """))
+                raise ValueError(
+                    cleandoc(
+                        f"""
+                        Registry does not contain required provider with key
+                        '{config.provider_key}' for config '{config.id}'
+                        Registered providers:
+                        {self.registry.get_registry_types_descriptions()}
+                        """
+                    )
+                )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/core/config/test_config_models.py
+++ b/tests/core/config/test_config_models.py
@@ -1,0 +1,98 @@
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from open_ticket_ai.src.core.config.config_models import (
+    OpenTicketAIConfig,
+    PipeConfig,
+    PipelineConfig,
+    ScheduleConfig,
+    SystemConfig,
+    load_config,
+)
+
+
+def test_load_config_success(tmp_path: Path) -> None:
+    content = textwrap.dedent(
+        """
+        open_ticket_ai:
+          system:
+            id: system
+            provider_key: SystemProvider
+          pipes:
+            - id: p1
+              provider_key: Provider1
+            - id: p2
+              provider_key: Provider2
+          pipelines:
+            - id: pipe_line
+              schedule:
+                interval: 5
+                unit: seconds
+              pipes:
+                - p1
+                - p2
+        """
+    )
+    path = tmp_path / "config.yml"
+    path.write_text(content)
+
+    cfg = load_config(path)
+
+    assert cfg.system.id == "system"
+    assert [p.id for p in cfg.pipes] == ["p1", "p2"]
+    assert cfg.pipelines[0].schedule.unit == "seconds"
+
+
+def test_load_config_missing_root_key(tmp_path: Path) -> None:
+    path = tmp_path / "config.yml"
+    path.write_text("system: {}\n")
+
+    with pytest.raises(KeyError):
+        load_config(path)
+
+
+def test_pipeline_validation_unknown_pipe(tmp_path: Path) -> None:
+    content = textwrap.dedent(
+        """
+        open_ticket_ai:
+          system:
+            id: system
+            provider_key: SystemProvider
+          pipes:
+            - id: p1
+              provider_key: Provider1
+          pipelines:
+            - id: pipe_line
+              schedule:
+                interval: 5
+                unit: seconds
+              pipes:
+                - p1
+                - p2
+        """
+    )
+    path = tmp_path / "config.yml"
+    path.write_text(content)
+
+    with pytest.raises(ValueError):
+        load_config(path)
+
+
+def test_get_all_register_instance_configs() -> None:
+    cfg = OpenTicketAIConfig(
+        system=SystemConfig(id="sys", provider_key="SystemProvider"),
+        pipes=[
+            PipeConfig(id="p1", provider_key="Provider1"),
+            PipeConfig(id="p2", provider_key="Provider2"),
+        ],
+        pipelines=[
+            PipelineConfig(
+                id="pl", schedule=ScheduleConfig(interval=1, unit="seconds"), pipes=["p1", "p2"]
+            )
+        ],
+    )
+
+    ids = [c.id for c in cfg.get_all_register_instance_configs()]
+    assert ids == ["sys", "p1", "p2"]

--- a/tests/core/config/test_config_validator.py
+++ b/tests/core/config/test_config_validator.py
@@ -1,0 +1,78 @@
+import pytest
+
+from open_ticket_ai.src.core.config.config_models import (
+    OpenTicketAIConfig,
+    PipeConfig,
+    PipelineConfig,
+    ScheduleConfig,
+    SystemConfig,
+)
+from open_ticket_ai.src.core.config.config_validator import OpenTicketAIConfigValidator
+from open_ticket_ai.src.core.dependency_injection.registry import Registry
+
+
+class DummySystemProvider:
+    @classmethod
+    def get_provider_key(cls) -> str:  # pragma: no cover - simple provider
+        return cls.__name__
+
+    @classmethod
+    def get_description(cls) -> str:
+        return "system"
+
+
+class DummyPipe1Provider:
+    @classmethod
+    def get_provider_key(cls) -> str:  # pragma: no cover - simple provider
+        return cls.__name__
+
+    @classmethod
+    def get_description(cls) -> str:
+        return "pipe1"
+
+
+class DummyPipe2Provider:
+    @classmethod
+    def get_provider_key(cls) -> str:  # pragma: no cover - simple provider
+        return cls.__name__
+
+    @classmethod
+    def get_description(cls) -> str:
+        return "pipe2"
+
+
+def build_config() -> OpenTicketAIConfig:
+    return OpenTicketAIConfig(
+        system=SystemConfig(id="sys", provider_key=DummySystemProvider.get_provider_key()),
+        pipes=[
+            PipeConfig(id="p1", provider_key=DummyPipe1Provider.get_provider_key()),
+            PipeConfig(id="p2", provider_key=DummyPipe2Provider.get_provider_key()),
+        ],
+        pipelines=[
+            PipelineConfig(
+                id="pl", schedule=ScheduleConfig(interval=1, unit="seconds"), pipes=["p1", "p2"]
+            )
+        ],
+    )
+
+
+def test_validate_registry_success() -> None:
+    cfg = build_config()
+    registry = Registry()
+    registry.register_all([DummySystemProvider, DummyPipe1Provider, DummyPipe2Provider])
+    validator = OpenTicketAIConfigValidator(cfg, registry)
+
+    # Should not raise
+    validator.validate_registry()
+
+
+def test_validate_registry_missing_provider() -> None:
+    cfg = build_config()
+    registry = Registry()
+    registry.register_all([DummySystemProvider, DummyPipe1Provider])
+    validator = OpenTicketAIConfigValidator(cfg, registry)
+
+    with pytest.raises(ValueError) as exc:
+        validator.validate_registry()
+
+    assert DummyPipe2Provider.get_provider_key() in str(exc.value)


### PR DESCRIPTION
## Summary
- clarify registry validation error messages to reference missing provider keys
- add unit tests for config model loading and cross-validation
- test config validator with registry presence and absence cases

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5d51e9a608327a8ec93817dcf6cef