### PR TITLE
Ensure TicketQueueUpdater handles queue mapping and low confidence

### DIFF
--- a/open_ticket_ai/src/base/pipe_implementations/ticket_fetcher/queue_ticket_fetcher.py
+++ b/open_ticket_ai/src/base/pipe_implementations/ticket_fetcher/queue_ticket_fetcher.py
@@ -7,7 +7,9 @@ from open_ticket_ai.src.core.pipeline.pipe import Pipe
 from open_ticket_ai.src.core.ticket_system_integration.ticket_system_adapter import TicketSystemAdapter
 
 
-class QueueTicketFetcher(Pipe[EmptyDataModel, QueueTicketFetcherOutput]):
+class QueueTicketFetcher(
+    Pipe[ProvidableConfig, EmptyDataModel, QueueTicketFetcherOutput]
+):
 
     def __init__(self, config: ProvidableConfig, ticket_system: TicketSystemAdapter):
         super().__init__(config)

--- a/open_ticket_ai/src/base/pipe_implementations/ticket_queue_updater/ticket_queue_updater.py
+++ b/open_ticket_ai/src/base/pipe_implementations/ticket_queue_updater/ticket_queue_updater.py
@@ -1,27 +1,95 @@
-from open_ticket_ai.src.base.pipe_implementations.hf_inference_services.models import HFLocalAIInferenceServiceOutput
-from open_ticket_ai.src.core.config.config_models import ProvidableConfig
+"""Pipe implementation for updating a ticket's queue in the ticket system.
+
+This pipe consumes the prediction of the preceding inference service and writes the
+result back to the ticket system.  It needs to deal with a couple of edge cases:
+
+* The prediction produced by the model might not use the same values as the ticket
+  system.  A mapping between model predictions and ticket system values is therefore
+  required.
+* When the confidence of the prediction is below a configurable threshold the ticket
+  should be routed to a *fallback* queue instead of the predicted one.
+* The underlying ``TicketSystemAdapter`` exposes asynchronous methods.  The pipeline
+  itself is synchronous though, therefore we have to run the coroutine explicitly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from open_ticket_ai.src.base.pipe_implementations.hf_inference_services.models import (
+    HFLocalAIInferenceServiceOutput,
+)
+from open_ticket_ai.src.base.pipe_implementations.empty_data_model import EmptyDataModel
+from open_ticket_ai.src.base.pipe_implementations.ticket_queue_updater.models import (
+    TicketQueueUpdaterConfig,
+)
 from open_ticket_ai.src.core.pipeline.context import PipelineContext
 from open_ticket_ai.src.core.pipeline.pipe import Pipe
-from open_ticket_ai.src.core.ticket_system_integration.ticket_system_adapter import TicketSystemAdapter
-from open_ticket_ai.src.core.ticket_system_integration.unified_models import UnifiedTicket, UnifiedQueue
-from open_ticket_ai.src.base.pipe_implementations.empty_data_model import EmptyDataModel
+from open_ticket_ai.src.core.ticket_system_integration.ticket_system_adapter import (
+    TicketSystemAdapter,
+)
+from open_ticket_ai.src.core.ticket_system_integration.unified_models import (
+    UnifiedQueue,
+    UnifiedTicket,
+)
 
 
-class TicketQueueUpdater(Pipe[HFLocalAIInferenceServiceOutput, EmptyDataModel]):
-    def __init__(self, config: ProvidableConfig, ticket_system: TicketSystemAdapter):
+class TicketQueueUpdater(
+    Pipe[TicketQueueUpdaterConfig, HFLocalAIInferenceServiceOutput, EmptyDataModel]
+):
+    """Translate model predictions into ticket system queue updates."""
+
+    def __init__(
+        self, config: TicketQueueUpdaterConfig, ticket_system: TicketSystemAdapter
+    ) -> None:
         super().__init__(config)
+        # ``TicketQueueUpdaterConfig`` contains all knobs required to translate the
+        # prediction into a value understood by the ticket system.
         self.modifier_config = config
         self.ticket_system = ticket_system
 
-    def process(self, context: PipelineContext[HFLocalAIInferenceServiceOutput]) -> PipelineContext[EmptyDataModel]:
+    # ------------------------------------------------------------------
+    def _prediction_to_queue(self, prediction: str | int) -> str | int:
+        """Map a model prediction to the ticket system queue value.
+
+        ``TicketQueueUpdaterConfig.ticket_system_value2model_values`` stores the
+        ticket system value as key and the corresponding model value as value.
+        We therefore need to invert this mapping when looking up the queue name.
+        If no mapping is found we simply fall back to the prediction itself.
+        """
+
+        for ticket_value, model_value in (
+            self.modifier_config.ticket_system_value2model_values or {}
+        ).items():
+            if model_value == prediction:
+                return ticket_value
+        return prediction
+
+    # ------------------------------------------------------------------
+    def process(
+        self, context: PipelineContext[HFLocalAIInferenceServiceOutput]
+    ) -> PipelineContext[EmptyDataModel]:
         update_data = context.data
         if update_data:
-            self.ticket_system.update_ticket(
-                context.data.ticket.id,
-                UnifiedTicket(queue=UnifiedQueue(name=context.data.prediction))
+            # Determine which queue should be used.  Low confidence predictions are
+            # routed to the configured fallback queue.
+            if (
+                update_data.confidence
+                < self.modifier_config.confidence_threshold
+            ):
+                queue_name = self.modifier_config.low_confidence_queue
+            else:
+                queue_name = self._prediction_to_queue(update_data.prediction)
+
+            # ``update_ticket`` is async – run it explicitly.
+            asyncio.run(
+                self.ticket_system.update_ticket(
+                    update_data.ticket.id,
+                    UnifiedTicket(queue=UnifiedQueue(name=queue_name)),
+                )
             )
+
         new_context = PipelineContext(
-            meta_info=context.meta_info,
-            data=EmptyDataModel()
+            meta_info=context.meta_info, data=EmptyDataModel()
         )
         return new_context

--- a/open_ticket_ai/tests/src/base/test_ticket_queue_updater.py
+++ b/open_ticket_ai/tests/src/base/test_ticket_queue_updater.py
@@ -1,0 +1,97 @@
+"""Tests for :mod:`ticket_queue_updater` pipe."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from open_ticket_ai.src.base.pipe_implementations.hf_inference_services.models import (
+    HFLocalAIInferenceServiceOutput,
+)
+from open_ticket_ai.src.base.pipe_implementations.ticket_queue_updater.models import (
+    TicketQueueUpdaterConfig,
+)
+from open_ticket_ai.src.base.pipe_implementations.ticket_queue_updater.ticket_queue_updater import (
+    TicketQueueUpdater,
+)
+from open_ticket_ai.src.base.pipe_implementations.empty_data_model import (
+    EmptyDataModel,
+)
+from open_ticket_ai.src.core.config.config_models import SystemConfig
+from open_ticket_ai.src.core.pipeline.context import PipelineContext
+from open_ticket_ai.src.core.ticket_system_integration.ticket_system_adapter import (
+    TicketSystemAdapter,
+)
+from open_ticket_ai.src.core.ticket_system_integration.unified_models import (
+    UnifiedQueue,
+    UnifiedTicket,
+)
+
+
+class DummyTicketSystem(TicketSystemAdapter):
+    """Minimal ticket system adapter used for testing."""
+
+    def __init__(self) -> None:  # pragma: no cover - simple passthrough
+        super().__init__(SystemConfig(id="sys", provider_key="dummy"))
+        self.updated: list[tuple[str, UnifiedTicket]] = []
+
+    async def update_ticket(self, ticket_id: str, updates: UnifiedTicket) -> bool:
+        self.updated.append((ticket_id, updates))
+        return True
+
+    async def find_tickets(self, criteria: Any) -> list[UnifiedTicket]:  # pragma: no cover - not used
+        return []
+
+    async def find_first_ticket(self, criteria: Any) -> UnifiedTicket | None:  # pragma: no cover - not used
+        return None
+
+
+def _make_context(prediction: str, confidence: float, ticket_id: str) -> PipelineContext:
+    return PipelineContext(
+        data=HFLocalAIInferenceServiceOutput(
+            prediction=prediction,
+            confidence=confidence,
+            ticket=UnifiedTicket(id=ticket_id),
+        )
+    )
+
+
+def _make_updater(**cfg_overrides: Any) -> tuple[TicketQueueUpdater, DummyTicketSystem]:
+    cfg = TicketQueueUpdaterConfig(
+        id="updater",
+        provider_key="updater",
+        confidence_threshold=0.8,
+        low_confidence_queue="General",
+        ticket_system_value2model_values={"Sales": "sales", "Support": "support"},
+        **cfg_overrides,
+    )
+    system = DummyTicketSystem()
+    return TicketQueueUpdater(cfg, system), system
+
+
+def test_updates_queue_when_confident() -> None:
+    updater, system = _make_updater()
+    context = _make_context("sales", 0.9, "42")
+
+    result = updater.process(context)
+
+    assert system.updated[0][0] == "42"
+    assert system.updated[0][1].queue == UnifiedQueue(name="Sales")
+    assert isinstance(result.data, EmptyDataModel)
+
+
+def test_uses_low_confidence_queue_when_below_threshold() -> None:
+    updater, system = _make_updater()
+    context = _make_context("sales", 0.5, "99")
+
+    updater.process(context)
+
+    assert system.updated[0][1].queue == UnifiedQueue(name="General")
+
+
+def test_no_update_when_no_data() -> None:
+    updater, system = _make_updater()
+
+    updater.process(PipelineContext())
+
+    assert system.updated == []
+


### PR DESCRIPTION
## Summary
- Map model predictions to ticket system queues with configurable fallback
- Execute asynchronous ticket updates properly
- Fix QueueTicketFetcher type parameters
- Add unit tests for TicketQueueUpdater

## Testing
- `pytest open_ticket_ai/tests/src/base/test_ticket_queue_updater.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6737937e0832791409ac637847942